### PR TITLE
Add temporary directory cleanup in artifact fetcher

### DIFF
--- a/conda_recipe_manager/fetcher/base_artifact_fetcher.py
+++ b/conda_recipe_manager/fetcher/base_artifact_fetcher.py
@@ -40,6 +40,12 @@ class BaseArtifactFetcher(metaclass=ABCMeta):
         # Flag to track if `fetch()` has been called successfully once.
         self._successfully_fetched = False
 
+    def __del__(self) -> None:
+        """Removes the temporary directory and all contents on deletion.
+        Avoids resource warnings during implicit tempfile cleanup.
+        """
+        self._temp_dir.cleanup()
+
     def _fetch_guard(self, msg: str) -> None:
         """
         Convenience function that prevents executing functions that require the code to be downloaded or stored to the


### PR DESCRIPTION
- avoids warnings about implicit cleanup in tests
- see #237

### Description

This is a very trivial change to avoid the warnings mentioned in #237 (came there from #369).
I guess there are no release notes needed for this one.

