### PR TITLE
Partially Fixes #407 - Duplicate Variable Names

### DIFF
--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -132,6 +132,15 @@ class Regex:
     # group. Failure to mark this may cause `findall()` to return empty strings if no other group is present in the
     # regex.
     _JINJA_OPTIONAL_EOL_COMMENT: Final[str] = r"[ \t]*(?:#[^\n]*)?$"
+    # Pattern that describes a single token in a JINJA concatenation expression. This could be a JINJA variable name or
+    # a quoted string or a number that allows spaces and other special characters. NOTE: The outer capture group
+    # captures the token, not the alternative inner forms.
+    #
+    # Examples:
+    #   number + 1
+    #   "foo" + var_bar
+    #   tests_to_ignore + " --ignore=streamlit_tests/lib/tests/streamlit/elements/cache_spinner_test.py"
+    _JINJA_FUNCTION_ADD_CONCAT_TOKEN: Final[str] = r"((?:[\w\.!]+)|(?:[\"\'][\w\.! \t\-=\/]+[\"\']))"
 
     # Pattern that attempts to identify YAML strings that need to be quote-escaped in the parsing process. Including:
     #   - Strings that start with a quote marker, close the same quote marker, and then are trailed by characters.
@@ -229,7 +238,7 @@ class Regex:
     )
     JINJA_FUNCTION_IDX_ACCESS: Final[re.Pattern[str]] = re.compile(r"(.+)\[(-?\d+)\]")
     JINJA_FUNCTION_ADD_CONCAT: Final[re.Pattern[str]] = re.compile(
-        r"([\"\']?[\w\.!]+[\"\']?)[ \t]+\+[ \t]*([\"\']?[\w\.!]+[\"\']?)"
+        _JINJA_FUNCTION_ADD_CONCAT_TOKEN + r"[ \t]+\+[ \t]*" + _JINJA_FUNCTION_ADD_CONCAT_TOKEN
     )
     # `match()` is a JINJA function available in the V1 recipe format
     JINJA_FUNCTION_MATCH: Final[re.Pattern[str]] = re.compile(r"match\(.*,.*\)")

--- a/conda_recipe_manager/parser/recipe_parser.py
+++ b/conda_recipe_manager/parser/recipe_parser.py
@@ -110,7 +110,7 @@ class RecipeParser(RecipeReader):
         :param var: Variable to modify
         :param value: Value to set
         """
-        self._vars_tbl[var] = NodeVar(value)
+        self._vars_tbl[var] = [NodeVar(value)]
         self._is_modified = True
 
     def del_variable(self, var: str) -> None:

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -156,7 +156,7 @@ class RecipeParserConvert(RecipeParserDeps):
             if len(node_vars) > 1:
                 self._msg_tbl.add_message(
                     MessageCategory.WARNING,
-                    f"The variable `{name}` is defined multiple times. This is scenario is not currently supported.",
+                    f"The variable `{name}` is defined multiple times. This scenario is not currently supported.",
                 )
                 continue
 

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -139,6 +139,7 @@ class RecipeParserConvert(RecipeParserDeps):
     ## Upgrade functions ##
 
     def _upgrade_jinja_to_context_obj(self) -> None:
+        # pylint: disable=too-complex
         """
         Upgrades the old proprietary JINJA templating usage to the new YAML-parsable `context` object and `$`-escaped
         JINJA substitutions.
@@ -148,7 +149,15 @@ class RecipeParserConvert(RecipeParserDeps):
         context_obj: dict[str, Primitives] = {}
         var_comments: dict[str, str] = {}
         # TODO Add selectors support? (I don't remember if V1 allows for selectors in `/context`)
-        for name, node_var in self._v1_recipe._vars_tbl.items():  # pylint: disable=protected-access
+        for name, node_vars in self._v1_recipe._vars_tbl.items():  # pylint: disable=protected-access
+            if len(node_vars) > 1:
+                self._msg_tbl.add_message(
+                    MessageCategory.WARNING,
+                    f"The variable `{name}` is defined multiple times. This is scenario is not currently supported.",
+                )
+                continue
+
+            node_var = node_vars[0]
             value = node_var.get_value()
             # Filter-out any value not covered in the V1 format
             if not isinstance(value, (str, int, float, bool)):

--- a/conda_recipe_manager/parser/recipe_reader.py
+++ b/conda_recipe_manager/parser/recipe_reader.py
@@ -460,7 +460,7 @@ class RecipeReader(IsModifiable):
             case SchemaVersion.V0:
                 if len(self._vars_tbl[key]) == 1:
                     return self._vars_tbl[key][0].get_value()
-                # TODO support recursive concatenation?
+                # TODO Future: Support recursive concatenation here. Until then, this is just a duplicated line.
                 return self._vars_tbl[key][0].get_value()
             case SchemaVersion.V1:
                 return self._vars_tbl[key][0].get_value()
@@ -630,6 +630,8 @@ class RecipeReader(IsModifiable):
 
         The vast, vast majority of recipe files follow a standard 2-space-tab convention. Although technically not
         required by YAML/conda-build, it is an assumption this parser makes to simplify an already complex file format.
+        `V0RecipeFormatter::fix_excessive_indentation()` should correct n > 2 tab lengths. This is invoked in this
+        function.
 
         :param internal_call: Whether this is an internal call. If true, we cannot determine if the recipe is V0 or V1.
         :returns: A sanitized version of the original recipe file text and a counter indicating how many comments exist

--- a/tests/parser/test_recipe_reader.py
+++ b/tests/parser/test_recipe_reader.py
@@ -172,7 +172,7 @@ def test_loading_obj_in_list() -> None:
 @pytest.mark.parametrize(
     "file",
     [
-        # V0 Recipe Files
+        #### V0 Recipe Files ####
         "types-toml.yaml",  # "Easy-difficulty" recipe, representative of common/simple recipes.
         "simple-recipe.yaml",  # "Medium-difficulty" recipe, containing several contrived examples
         "multi-output.yaml",  # Contains a multi-output recipe
@@ -189,7 +189,7 @@ def test_loading_obj_in_list() -> None:
         "x264.yaml",
         "parser_regressions/issue-366_quote_regressions_round_trip.yaml",
         "parser_regressions/issue-378_colon_quote_regression.yaml",
-        # V1 Recipe Files
+        #### V1 Recipe Files ####
         "v1_format/v1_types-toml.yaml",
         "v1_format/v1_simple-recipe.yaml",
         "v1_format/v1_multi-output.yaml",
@@ -207,10 +207,39 @@ def test_round_trip(file: str) -> None:
     """
     Test "eating our own dog food"/round-tripping the parser: Take a recipe, construct a parser, re-render and
     ensure the output matches the input.
+
+    :param file: Recipe file to round-trip.
     """
-    expected: Final[str] = load_file(file)
-    parser = RecipeReader(expected)
+    expected: Final = load_file(file)
+    parser: Final = RecipeReader(expected)
     assert parser.render() == expected
+
+
+@pytest.mark.parametrize(
+    "file,expected",
+    [
+        #### V0 Recipe Files ####
+        # Issue #407 is only partially resolved. But the partial solution is enough of a step in the right direction
+        # that it has been added.
+        # TODO Fix comments applying to JINJA variables are not moved with the JINJA set lines.
+        # TODO Add support to `RecipeReader::get_value()` for self-referenced concatenations(?)
+        (
+            "parser_regressions/issue-407_duplicate_jinja_vars_input_streamlit.yaml",
+            "parser_regressions/issue-407_duplicate_jinja_vars_parsed_streamlit.yaml",
+        ),
+        #### V1 Recipe Files ####
+    ],
+)
+def test_round_trip_with_changes(file: str, expected: str) -> None:
+    """
+    Like `test_round_trip()`, but for recipe files where we _expect_ changes in the final recipe. This includes recipe
+    files that can be parsed and rendered, but the rendered file is not identical to the input for one or more reasons.
+
+    :param file: Recipe file to parse.
+    :param expected: Expected rendered output of the parsed recipe file.
+    """
+    parser: Final = RecipeReader(load_file(file))
+    assert parser.render() == load_file(expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/parser/test_recipe_reader.py
+++ b/tests/parser/test_recipe_reader.py
@@ -52,8 +52,8 @@ def test_construction(file: str, schema_version: SchemaVersion) -> None:
     parser = RecipeReader(types_toml)
     assert parser._init_content == types_toml  # pylint: disable=protected-access
     assert parser._vars_tbl == {  # pylint: disable=protected-access
-        "name": NodeVar("types-toml", None),
-        "version": NodeVar("0.10.8.6", None),
+        "name": [NodeVar("types-toml", None)],
+        "version": [NodeVar("0.10.8.6", None)],
     }
     assert parser.get_schema_version() == schema_version
     assert not parser.is_modified()

--- a/tests/test_aux_files/parser_regressions/issue-407_duplicate_jinja_vars_input_streamlit.yaml
+++ b/tests/test_aux_files/parser_regressions/issue-407_duplicate_jinja_vars_input_streamlit.yaml
@@ -1,0 +1,219 @@
+{% set name = "streamlit" %}
+{% set version = "1.48.0" %}
+
+package:
+  name: {{ name|lower }}-split
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 64da4819f4b897c8d1e9eb6396f4618b2eb5029d25af61472422d4eb0688bb75
+    folder: streamlit
+    patches:
+      - patches/0001-move-pydeck-to-extra-deps.patch
+  - url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
+    sha256: 67dc94d90e89f7b77df85e64fb8f6cf9353e9e0d53e59f6d47c5834e013d6142
+    folder: streamlit_tests
+
+build:
+  number: 0
+  entry_points:
+    - streamlit = streamlit.web.cli:main
+  skip: True  # [py<39]
+
+requirements:
+  host:
+    - python
+  run:
+    - python
+
+outputs:
+  - name: streamlit
+    script: build-output.sh  # [not win]
+    script: build-output.bat  # [win]
+    build:
+      entry_points:
+        - streamlit = streamlit.web.cli:main
+    requirements:
+      host:
+        - pip
+        - python
+        - wheel
+        - setuptools
+      run:
+        - python
+        # Altair 5.4.0 and 5.4.1 have compatibility issues with narwhals library
+        # that cause st.line_chart and other built-in charts to fail rendering.
+        # See: https://github.com/streamlit/streamlit/issues/12064
+        - altair >=4.0,<6,!=5.4.0,!=5.4.1
+        - blinker >=1.5.0,<2
+        - cachetools >=4.0,<7
+        - click >=7.0,<9
+        - numpy >=1.23,<3
+        - packaging >=20,<26
+        # Pandas <1.4 has a bug related to deleting columns in a DataFrame changing
+        # the index dtype.
+        - pandas >=1.4.0,<3
+        - pillow >=7.1.0,<12
+        # `protoc` < 3.20 is not able to generate protobuf code compatible with protobuf >= 3.20.
+        - protobuf >=3.20,<7
+        # pyarrow is not semantically versioned, gets new major versions frequently, and
+        # doesn't tend to break the API on major version upgrades, so we don't put an
+        # upper bound on it.
+        - pyarrow >=7.0
+        - requests >=2.27,<3
+        - tenacity >=8.1.0,<10
+        # Starting from Python 3.11, Python has built in support for reading TOML files.
+        # Let's make sure to remove this "toml" library when we stop supporting Python 3.10.
+        - toml >=0.10.1,<2
+        - typing_extensions >=4.4.0,<5
+        # Don't require watchdog on MacOS, since it'll fail without xcode tools.
+        # Without watchdog, we fallback to a polling file watcher to check for app changes.
+        - watchdog >=2.1.5,<7  # [not osx]
+        # SNOWPARK_CONDA_EXCLUDED_DEPENDENCIES:
+        # We want to exclude some dependencies in our internal Snowpark conda distribution of
+        # Streamlit. These dependencies will be installed normally for both regular conda builds
+        # and PyPI builds (that is, for people installing streamlit using either
+        # `pip install streamlit` or `conda install -c conda-forge streamlit`)
+        - gitpython >=3.0.7,<4,!=3.1.19
+        # Tornado 6.0.3 was the current version when Python 3.8 was released (Oct 14, 2019).
+        # Tornado 6.5.0 is skipped due to a bug with Unicode characters in the filename.
+        # See https://github.com/tornadoweb/tornado/commit/62c276434dc5b13e10336666348408bf8c062391
+        - tornado >=6.0.3,<7,!=6.5.0
+      run_constrained:
+        - python !=3.9.7
+        - rich >=11.0.0
+        # snowflake
+        - snowflake-snowpark-python >=1.17.0  # [py<312]
+        - snowflake-connector-python >=3.3.0  # [py<312]
+        # SNOWPARK_CONDA_EXCLUDED_DEPENDENCIES:
+        # pydeck 0.9.1 and below restrict ipywidgets to version 7
+        # This leads to non-functional systems when installed with recent jupyterlab versions.
+        # Pydeck supports creating interactive map visualization, which is not the main feature of streamlit.
+        - pydeck >=0.8.0b4,<1
+        # auth
+        - authlib >=1.3.2
+        # charts
+        - matplotlib-base >=3.0.0
+        - python-graphviz >=0.19.0
+        - plotly >=4.0.0
+        - orjson >=3.5.0
+        # sql
+        - sqlalchemy >=2.0.0
+
+    test:
+      imports:
+        - streamlit
+      commands:
+        - pip check
+        - streamlit --help
+      requires:
+        - pip
+
+  - name: streamlit-tests
+    build:
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - {{ pin_subpackage('streamlit', exact=True) }}
+
+    # The test fails because "streamlit run" appears in the captured logs, likely due to Streamlit emitting a warning message that wasn't suppressed or filtered out.
+    # streamlit_tests\lib\tests\streamlit\delta_generator_test.py::RunWarningTest::test_run_warning_absence
+    # >       self.assertNotRegex("".join(logs.output), r"streamlit run")
+    # E       AssertionError: Regex matched: 'streamlit run' matches 'streamlit run' in 'WARNING:streamlit:\n  \x1b[33m\x1b[1mWarning:\x1b[0m to view a Streamlit app on a browser, use Streamlit in a file and\n  run it with the following command:\n\n    streamlit run [FILE_NAME] [ARGUMENTS]WARNING:streamlit:irrelevant warning so assertLogs passes'
+    {% set tests_to_skip = "test_run_warning_absence" %}
+
+    # This tests needs Google Microsoft credentials in .streamlit/secrets.toml to login with authlib. Won`t fix.
+    # >      assert (
+    #            "Authentication credentials in `.streamlit/secrets.toml` are missing for the "
+    #            'authentication provider "invalid_provider". Please check your configuration.'
+    #        ) == str(ex.exception)
+    {% set tests_to_skip = tests_to_skip + " or test_user_login" %}
+
+    # streamlit_tests\lib\tests\streamlit\config_test.py::ConfigTest::test_check_conflicts_server_csrf
+    # Logger troubles. For some reason mock_logger.warning.assert_called_once() return 0;
+    # >       raise AssertionError(msg)
+    # E       AssertionError: Expected 'warning' to have been called once. Called 0 times.
+    {% set tests_to_skip = tests_to_skip + " or test_check_conflicts_server_csrf" %}
+
+    # E       AssertionError: Median import time 864183us of streamlit exceeded the max allowed threshold 700000us (percentage: 123%).In case this is expected and justified, you can change the threshold in the test.
+    # E       assert 864183 <= 700000
+    {% set tests_to_skip = tests_to_skip + " or test_importtime_median_under_threshold" %}
+
+    # E       AssertionError: Welcome message mode is True and headless mode is False yet output is:
+    # E       assert ((True and not False)) == ('like to receive helpful onboarding emails, news, offers, promotions,' in '')
+    # E        +  where '' = <Result okay>.output
+    {% set tests_to_skip = tests_to_skip + " or test_prompt_welcome_message_2" %}
+
+    # The git_util_test.py tests skipped, no need to test git.
+    {% set tests_to_ignore = " --ignore=streamlit_tests/lib/tests/streamlit/git_util_test.py" %}
+    # Problems in MockSessionClient. Data frame can`t have enough time to make push in the MockSessionClient::list. I think await self.tick_runtime_loop() broken. Tests failed randomly on linux and windows.
+    {% set tests_to_ignore = tests_to_ignore + " --ignore=streamlit_tests/lib/tests/streamlit/runtime/runtime_test.py" %}
+    # The test fails with RuntimeError: Runtime instance already exists!, which suggests that the server is already running when self.server.start() is called.
+    # The test class may not be properly resetting the environment between tests - setUp() or tearDown() issues.
+    {% set tests_to_ignore = tests_to_ignore + " --ignore=streamlit_tests/lib/tests/streamlit/web/server/component_request_handler_test.py" %}
+    {% set tests_to_ignore = tests_to_ignore + " --ignore=streamlit_tests/lib/tests/streamlit/web/server/server_test.py" %}
+    {% set tests_to_ignore = tests_to_ignore + " --ignore=streamlit_tests/lib/tests/streamlit/web/server/media_file_handler_test.py" %}
+    {% set tests_to_ignore = tests_to_ignore + " --ignore=streamlit_tests/lib/tests/streamlit/web/server/routes_test.py" %}
+    {% set tests_to_ignore = tests_to_ignore + " --ignore=streamlit_tests/lib/tests/streamlit/web/server/upload_file_request_handler_test.py" %}
+    # >       assert el.spinner.show_time is True
+    # E       assert False is True
+    # E        +  where False = .show_time
+    # E        +    where  = empty {\n}\n.spinner
+    {% set tests_to_ignore = tests_to_ignore + " --ignore=streamlit_tests/lib/tests/streamlit/elements/cache_spinner_test.py" %}  # [osx]
+
+    test:
+      source_files:
+        - streamlit_tests/lib/tests
+        - streamlit_tests/lib/setup.py
+        - streamlit_tests/lib/pytest.ini
+      imports:
+        - streamlit
+      commands:
+        - pip check
+        - streamlit --help
+        - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+        # Adds missing MIME types to mimetypes to prevent ie: AssertionError: assert 'application/octet-stream' == 'font/otf'
+        - cat $RECIPE_DIR/parent/add_missing_mime_types.py >> streamlit_tests/lib/tests/conftest.py  # [linux]
+        - pytest -n 1 -v -m "not (require_integration or slow or performance)" -k "not ({{ tests_to_skip }})" {{ tests_to_ignore }} streamlit_tests/lib/tests  # [not win]
+      requires:
+        - pip
+        - pytest >=8.3.5
+        - parameterized
+        - authlib >=1.3.2
+        - requests-mock
+        - watchdog >=2.1.5
+        - plotly >=5.3.1
+        - pydeck
+        - testfixtures
+        - matplotlib-base >=3.3.4
+        - hypothesis >=6.17.4
+        - python-graphviz >=0.17
+        - pytest-benchmark 5.1.0
+        - pytest-xdist >=3.6.1
+        - pytest-rerunfailures
+        - pytest-cov
+
+about:
+  home: https://streamlit.io
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: The fastest way to build data apps in Python
+  description: |
+    Streamlit lets you turn data scripts into sharable web apps in minutes, not weeks.
+    It's all Python, open-source, and free!
+  doc_url: https://docs.streamlit.io
+  dev_url: https://github.com/streamlit/streamlit
+
+extra:
+  recipe-maintainers:
+    - raybellwaves
+    - randyzwitch
+    - kmcgrady
+  skip-lints:
+    # As we are only running the pytests in streamlit-tests we do not require python build tools
+    - missing_python_build_tool
+    - missing_wheel

--- a/tests/test_aux_files/parser_regressions/issue-407_duplicate_jinja_vars_parsed_streamlit.yaml
+++ b/tests/test_aux_files/parser_regressions/issue-407_duplicate_jinja_vars_parsed_streamlit.yaml
@@ -1,0 +1,210 @@
+{% set name = "streamlit" %}
+{% set version = "1.48.0" %}
+{% set tests_to_skip = "test_run_warning_absence" %}
+{% set tests_to_skip = tests_to_skip + " or test_user_login" %}
+{% set tests_to_skip = tests_to_skip + " or test_check_conflicts_server_csrf" %}
+{% set tests_to_skip = tests_to_skip + " or test_importtime_median_under_threshold" %}
+{% set tests_to_skip = tests_to_skip + " or test_prompt_welcome_message_2" %}
+{% set tests_to_ignore = " --ignore=streamlit_tests/lib/tests/streamlit/git_util_test.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=streamlit_tests/lib/tests/streamlit/runtime/runtime_test.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=streamlit_tests/lib/tests/streamlit/web/server/component_request_handler_test.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=streamlit_tests/lib/tests/streamlit/web/server/server_test.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=streamlit_tests/lib/tests/streamlit/web/server/media_file_handler_test.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=streamlit_tests/lib/tests/streamlit/web/server/routes_test.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=streamlit_tests/lib/tests/streamlit/web/server/upload_file_request_handler_test.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=streamlit_tests/lib/tests/streamlit/elements/cache_spinner_test.py" %}  # [osx]
+
+package:
+  name: {{ name|lower }}-split
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 64da4819f4b897c8d1e9eb6396f4618b2eb5029d25af61472422d4eb0688bb75
+    folder: streamlit
+    patches:
+      - patches/0001-move-pydeck-to-extra-deps.patch
+  - url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
+    sha256: 67dc94d90e89f7b77df85e64fb8f6cf9353e9e0d53e59f6d47c5834e013d6142
+    folder: streamlit_tests
+
+build:
+  number: 0
+  entry_points:
+    - streamlit = streamlit.web.cli:main
+  skip: true  # [py<39]
+
+requirements:
+  host:
+    - python
+  run:
+    - python
+
+outputs:
+  - name: streamlit
+    script: build-output.sh  # [not win]
+    script: build-output.bat  # [win]
+    build:
+      entry_points:
+        - streamlit = streamlit.web.cli:main
+    requirements:
+      host:
+        - pip
+        - python
+        - wheel
+        - setuptools
+      run:
+        - python
+        # Altair 5.4.0 and 5.4.1 have compatibility issues with narwhals library
+        # that cause st.line_chart and other built-in charts to fail rendering.
+        # See: https://github.com/streamlit/streamlit/issues/12064
+        - altair >=4.0,<6,!=5.4.0,!=5.4.1
+        - blinker >=1.5.0,<2
+        - cachetools >=4.0,<7
+        - click >=7.0,<9
+        - numpy >=1.23,<3
+        - packaging >=20,<26
+        # Pandas <1.4 has a bug related to deleting columns in a DataFrame changing
+        # the index dtype.
+        - pandas >=1.4.0,<3
+        - pillow >=7.1.0,<12
+        # `protoc` < 3.20 is not able to generate protobuf code compatible with protobuf >= 3.20.
+        - protobuf >=3.20,<7
+        # pyarrow is not semantically versioned, gets new major versions frequently, and
+        # doesn't tend to break the API on major version upgrades, so we don't put an
+        # upper bound on it.
+        - pyarrow >=7.0
+        - requests >=2.27,<3
+        - tenacity >=8.1.0,<10
+        # Starting from Python 3.11, Python has built in support for reading TOML files.
+        # Let's make sure to remove this "toml" library when we stop supporting Python 3.10.
+        - toml >=0.10.1,<2
+        - typing_extensions >=4.4.0,<5
+        # Don't require watchdog on MacOS, since it'll fail without xcode tools.
+        # Without watchdog, we fallback to a polling file watcher to check for app changes.
+        - watchdog >=2.1.5,<7  # [not osx]
+        # SNOWPARK_CONDA_EXCLUDED_DEPENDENCIES:
+        # We want to exclude some dependencies in our internal Snowpark conda distribution of
+        # Streamlit. These dependencies will be installed normally for both regular conda builds
+        # and PyPI builds (that is, for people installing streamlit using either
+        # `pip install streamlit` or `conda install -c conda-forge streamlit`)
+        - gitpython >=3.0.7,<4,!=3.1.19
+        # Tornado 6.0.3 was the current version when Python 3.8 was released (Oct 14, 2019).
+        # Tornado 6.5.0 is skipped due to a bug with Unicode characters in the filename.
+        # See https://github.com/tornadoweb/tornado/commit/62c276434dc5b13e10336666348408bf8c062391
+        - tornado >=6.0.3,<7,!=6.5.0
+      run_constrained:
+        - python !=3.9.7
+        - rich >=11.0.0
+        # snowflake
+        - snowflake-snowpark-python >=1.17.0  # [py<312]
+        - snowflake-connector-python >=3.3.0  # [py<312]
+        # SNOWPARK_CONDA_EXCLUDED_DEPENDENCIES:
+        # pydeck 0.9.1 and below restrict ipywidgets to version 7
+        # This leads to non-functional systems when installed with recent jupyterlab versions.
+        # Pydeck supports creating interactive map visualization, which is not the main feature of streamlit.
+        - pydeck >=0.8.0b4,<1
+        # auth
+        - authlib >=1.3.2
+        # charts
+        - matplotlib-base >=3.0.0
+        - python-graphviz >=0.19.0
+        - plotly >=4.0.0
+        - orjson >=3.5.0
+        # sql
+        - sqlalchemy >=2.0.0
+    test:
+      imports:
+        - streamlit
+      commands:
+        - pip check
+        - streamlit --help
+      requires:
+        - pip
+  - name: streamlit-tests
+    build:
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - {{ pin_subpackage('streamlit', exact=True) }}
+    # The test fails because "streamlit run" appears in the captured logs, likely due to Streamlit emitting a warning message that wasn't suppressed or filtered out.
+    # streamlit_tests\lib\tests\streamlit\delta_generator_test.py::RunWarningTest::test_run_warning_absence
+    # >       self.assertNotRegex("".join(logs.output), r"streamlit run")
+    # E       AssertionError: Regex matched: 'streamlit run' matches 'streamlit run' in 'WARNING:streamlit:\n  \x1b[33m\x1b[1mWarning:\x1b[0m to view a Streamlit app on a browser, use Streamlit in a file and\n  run it with the following command:\n\n    streamlit run [FILE_NAME] [ARGUMENTS]WARNING:streamlit:irrelevant warning so assertLogs passes'
+    # This tests needs Google Microsoft credentials in .streamlit/secrets.toml to login with authlib. Won`t fix.
+    # >      assert (
+    #            "Authentication credentials in `.streamlit/secrets.toml` are missing for the "
+    #            'authentication provider "invalid_provider". Please check your configuration.'
+    #        ) == str(ex.exception)
+    # streamlit_tests\lib\tests\streamlit\config_test.py::ConfigTest::test_check_conflicts_server_csrf
+    # Logger troubles. For some reason mock_logger.warning.assert_called_once() return 0;
+    # >       raise AssertionError(msg)
+    # E       AssertionError: Expected 'warning' to have been called once. Called 0 times.
+    # E       AssertionError: Median import time 864183us of streamlit exceeded the max allowed threshold 700000us (percentage: 123%).In case this is expected and justified, you can change the threshold in the test.
+    # E       assert 864183 <= 700000
+    # E       AssertionError: Welcome message mode is True and headless mode is False yet output is:
+    # E       assert ((True and not False)) == ('like to receive helpful onboarding emails, news, offers, promotions,' in '')
+    # E        +  where '' = <Result okay>.output
+    # The git_util_test.py tests skipped, no need to test git.
+    # Problems in MockSessionClient. Data frame can`t have enough time to make push in the MockSessionClient::list. I think await self.tick_runtime_loop() broken. Tests failed randomly on linux and windows.
+    # The test fails with RuntimeError: Runtime instance already exists!, which suggests that the server is already running when self.server.start() is called.
+    # The test class may not be properly resetting the environment between tests - setUp() or tearDown() issues.
+    # >       assert el.spinner.show_time is True
+    # E       assert False is True
+    # E        +  where False = .show_time
+    # E        +    where  = empty {\n}\n.spinner
+    test:
+      source_files:
+        - streamlit_tests/lib/tests
+        - streamlit_tests/lib/setup.py
+        - streamlit_tests/lib/pytest.ini
+      imports:
+        - streamlit
+      commands:
+        - pip check
+        - streamlit --help
+        - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+        # Adds missing MIME types to mimetypes to prevent ie: AssertionError: assert 'application/octet-stream' == 'font/otf'
+        - cat $RECIPE_DIR/parent/add_missing_mime_types.py >> streamlit_tests/lib/tests/conftest.py  # [linux]
+        - pytest -n 1 -v -m "not (require_integration or slow or performance)" -k "not ({{ tests_to_skip }})" {{ tests_to_ignore }} streamlit_tests/lib/tests  # [not win]
+      requires:
+        - pip
+        - pytest >=8.3.5
+        - parameterized
+        - authlib >=1.3.2
+        - requests-mock
+        - watchdog >=2.1.5
+        - plotly >=5.3.1
+        - pydeck
+        - testfixtures
+        - matplotlib-base >=3.3.4
+        - hypothesis >=6.17.4
+        - python-graphviz >=0.17
+        - pytest-benchmark 5.1.0
+        - pytest-xdist >=3.6.1
+        - pytest-rerunfailures
+        - pytest-cov
+
+about:
+  home: https://streamlit.io
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: The fastest way to build data apps in Python
+  description: |
+    Streamlit lets you turn data scripts into sharable web apps in minutes, not weeks.
+    It's all Python, open-source, and free!
+  doc_url: https://docs.streamlit.io
+  dev_url: https://github.com/streamlit/streamlit
+
+extra:
+  recipe-maintainers:
+    - raybellwaves
+    - randyzwitch
+    - kmcgrady
+  skip-lints:
+    # As we are only running the pytests in streamlit-tests we do not require python build tools
+    - missing_python_build_tool
+    - missing_wheel


### PR DESCRIPTION
Partially fixes #407 by adding _some_ support for duplicate variable names.

Still TODO (in future work):
- Move associated comments with the applicable variables.
- Add support for concatenation in `RecipeReader::_eval_var()`