### PR TITLE
Fixes #423

### DIFF
--- a/conda_recipe_manager/licenses/spdx_licenses.json
+++ b/conda_recipe_manager/licenses/spdx_licenses.json
@@ -1,11 +1,11 @@
 {
-  "licenseListVersion": "2f5d59d",
+  "licenseListVersion": "f54d7c8",
   "licenses": [
     {
       "reference": "https://spdx.org/licenses/0BSD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/0BSD.json",
-      "referenceNumber": 304,
+      "referenceNumber": 334,
       "name": "BSD Zero Clause License",
       "licenseId": "0BSD",
       "seeAlso": [
@@ -15,10 +15,23 @@
       "isOsiApproved": true
     },
     {
+      "reference": "https://spdx.org/licenses/3D-Slicer-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/3D-Slicer-1.0.json",
+      "referenceNumber": 251,
+      "name": "3D Slicer License v1.0",
+      "licenseId": "3D-Slicer-1.0",
+      "seeAlso": [
+        "https://slicer.org/LICENSE",
+        "https://github.com/Slicer/Slicer/blob/main/License.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/AAL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AAL.json",
-      "referenceNumber": 594,
+      "referenceNumber": 115,
       "name": "Attribution Assurance License",
       "licenseId": "AAL",
       "seeAlso": [
@@ -30,7 +43,7 @@
       "reference": "https://spdx.org/licenses/Abstyles.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Abstyles.json",
-      "referenceNumber": 557,
+      "referenceNumber": 140,
       "name": "Abstyles License",
       "licenseId": "Abstyles",
       "seeAlso": [
@@ -42,7 +55,7 @@
       "reference": "https://spdx.org/licenses/AdaCore-doc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AdaCore-doc.json",
-      "referenceNumber": 418,
+      "referenceNumber": 674,
       "name": "AdaCore Doc License",
       "licenseId": "AdaCore-doc",
       "seeAlso": [
@@ -56,7 +69,7 @@
       "reference": "https://spdx.org/licenses/Adobe-2006.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Adobe-2006.json",
-      "referenceNumber": 303,
+      "referenceNumber": 610,
       "name": "Adobe Systems Incorporated Source Code License Agreement",
       "licenseId": "Adobe-2006",
       "seeAlso": [
@@ -68,7 +81,7 @@
       "reference": "https://spdx.org/licenses/Adobe-Display-PostScript.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Adobe-Display-PostScript.json",
-      "referenceNumber": 13,
+      "referenceNumber": 505,
       "name": "Adobe Display PostScript License",
       "licenseId": "Adobe-Display-PostScript",
       "seeAlso": [
@@ -80,7 +93,7 @@
       "reference": "https://spdx.org/licenses/Adobe-Glyph.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Adobe-Glyph.json",
-      "referenceNumber": 330,
+      "referenceNumber": 560,
       "name": "Adobe Glyph List License",
       "licenseId": "Adobe-Glyph",
       "seeAlso": [
@@ -92,7 +105,7 @@
       "reference": "https://spdx.org/licenses/Adobe-Utopia.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Adobe-Utopia.json",
-      "referenceNumber": 273,
+      "referenceNumber": 554,
       "name": "Adobe Utopia Font License",
       "licenseId": "Adobe-Utopia",
       "seeAlso": [
@@ -104,7 +117,7 @@
       "reference": "https://spdx.org/licenses/ADSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ADSL.json",
-      "referenceNumber": 293,
+      "referenceNumber": 343,
       "name": "Amazon Digital Services License",
       "licenseId": "ADSL",
       "seeAlso": [
@@ -116,7 +129,7 @@
       "reference": "https://spdx.org/licenses/AFL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-1.1.json",
-      "referenceNumber": 477,
+      "referenceNumber": 42,
       "name": "Academic Free License v1.1",
       "licenseId": "AFL-1.1",
       "seeAlso": [
@@ -130,7 +143,7 @@
       "reference": "https://spdx.org/licenses/AFL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-1.2.json",
-      "referenceNumber": 140,
+      "referenceNumber": 253,
       "name": "Academic Free License v1.2",
       "licenseId": "AFL-1.2",
       "seeAlso": [
@@ -144,7 +157,7 @@
       "reference": "https://spdx.org/licenses/AFL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-2.0.json",
-      "referenceNumber": 60,
+      "referenceNumber": 533,
       "name": "Academic Free License v2.0",
       "licenseId": "AFL-2.0",
       "seeAlso": [
@@ -157,7 +170,7 @@
       "reference": "https://spdx.org/licenses/AFL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-2.1.json",
-      "referenceNumber": 295,
+      "referenceNumber": 358,
       "name": "Academic Free License v2.1",
       "licenseId": "AFL-2.1",
       "seeAlso": [
@@ -170,7 +183,7 @@
       "reference": "https://spdx.org/licenses/AFL-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-3.0.json",
-      "referenceNumber": 18,
+      "referenceNumber": 375,
       "name": "Academic Free License v3.0",
       "licenseId": "AFL-3.0",
       "seeAlso": [
@@ -184,7 +197,7 @@
       "reference": "https://spdx.org/licenses/Afmparse.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Afmparse.json",
-      "referenceNumber": 437,
+      "referenceNumber": 379,
       "name": "Afmparse License",
       "licenseId": "Afmparse",
       "seeAlso": [
@@ -196,7 +209,7 @@
       "reference": "https://spdx.org/licenses/AGPL-1.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/AGPL-1.0.json",
-      "referenceNumber": 103,
+      "referenceNumber": 208,
       "name": "Affero General Public License v1.0",
       "licenseId": "AGPL-1.0",
       "seeAlso": [
@@ -209,7 +222,7 @@
       "reference": "https://spdx.org/licenses/AGPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AGPL-1.0-only.json",
-      "referenceNumber": 389,
+      "referenceNumber": 517,
       "name": "Affero General Public License v1.0 only",
       "licenseId": "AGPL-1.0-only",
       "seeAlso": [
@@ -221,7 +234,7 @@
       "reference": "https://spdx.org/licenses/AGPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AGPL-1.0-or-later.json",
-      "referenceNumber": 331,
+      "referenceNumber": 262,
       "name": "Affero General Public License v1.0 or later",
       "licenseId": "AGPL-1.0-or-later",
       "seeAlso": [
@@ -233,7 +246,7 @@
       "reference": "https://spdx.org/licenses/AGPL-3.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/AGPL-3.0.json",
-      "referenceNumber": 372,
+      "referenceNumber": 473,
       "name": "GNU Affero General Public License v3.0",
       "licenseId": "AGPL-3.0",
       "seeAlso": [
@@ -247,7 +260,7 @@
       "reference": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-only.json",
-      "referenceNumber": 600,
+      "referenceNumber": 479,
       "name": "GNU Affero General Public License v3.0 only",
       "licenseId": "AGPL-3.0-only",
       "seeAlso": [
@@ -261,7 +274,7 @@
       "reference": "https://spdx.org/licenses/AGPL-3.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-or-later.json",
-      "referenceNumber": 593,
+      "referenceNumber": 493,
       "name": "GNU Affero General Public License v3.0 or later",
       "licenseId": "AGPL-3.0-or-later",
       "seeAlso": [
@@ -275,7 +288,7 @@
       "reference": "https://spdx.org/licenses/Aladdin.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Aladdin.json",
-      "referenceNumber": 562,
+      "referenceNumber": 53,
       "name": "Aladdin Free Public License",
       "licenseId": "Aladdin",
       "seeAlso": [
@@ -288,7 +301,7 @@
       "reference": "https://spdx.org/licenses/AMD-newlib.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AMD-newlib.json",
-      "referenceNumber": 365,
+      "referenceNumber": 199,
       "name": "AMD newlib License",
       "licenseId": "AMD-newlib",
       "seeAlso": [
@@ -300,7 +313,7 @@
       "reference": "https://spdx.org/licenses/AMDPLPA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AMDPLPA.json",
-      "referenceNumber": 552,
+      "referenceNumber": 312,
       "name": "AMD\u0027s plpa_map.c License",
       "licenseId": "AMDPLPA",
       "seeAlso": [
@@ -312,7 +325,7 @@
       "reference": "https://spdx.org/licenses/AML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AML.json",
-      "referenceNumber": 284,
+      "referenceNumber": 507,
       "name": "Apple MIT License",
       "licenseId": "AML",
       "seeAlso": [
@@ -324,7 +337,7 @@
       "reference": "https://spdx.org/licenses/AML-glslang.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AML-glslang.json",
-      "referenceNumber": 63,
+      "referenceNumber": 308,
       "name": "AML glslang variant License",
       "licenseId": "AML-glslang",
       "seeAlso": [
@@ -337,7 +350,7 @@
       "reference": "https://spdx.org/licenses/AMPAS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AMPAS.json",
-      "referenceNumber": 50,
+      "referenceNumber": 482,
       "name": "Academy of Motion Picture Arts and Sciences BSD",
       "licenseId": "AMPAS",
       "seeAlso": [
@@ -349,7 +362,7 @@
       "reference": "https://spdx.org/licenses/ANTLR-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ANTLR-PD.json",
-      "referenceNumber": 510,
+      "referenceNumber": 96,
       "name": "ANTLR Software Rights Notice",
       "licenseId": "ANTLR-PD",
       "seeAlso": [
@@ -361,7 +374,7 @@
       "reference": "https://spdx.org/licenses/ANTLR-PD-fallback.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ANTLR-PD-fallback.json",
-      "referenceNumber": 224,
+      "referenceNumber": 442,
       "name": "ANTLR Software Rights Notice with license fallback",
       "licenseId": "ANTLR-PD-fallback",
       "seeAlso": [
@@ -373,7 +386,7 @@
       "reference": "https://spdx.org/licenses/any-OSI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/any-OSI.json",
-      "referenceNumber": 308,
+      "referenceNumber": 489,
       "name": "Any OSI License",
       "licenseId": "any-OSI",
       "seeAlso": [
@@ -382,10 +395,24 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/any-OSI-perl-modules.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/any-OSI-perl-modules.json",
+      "referenceNumber": 618,
+      "name": "Any OSI License - Perl Modules",
+      "licenseId": "any-OSI-perl-modules",
+      "seeAlso": [
+        "https://metacpan.org/release/JUERD/Exporter-Tidy-0.09/view/Tidy.pm#LICENSE",
+        "https://metacpan.org/pod/Qmail::Deliverable::Client#LICENSE",
+        "https://metacpan.org/pod/Net::MQTT::Simple#LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/Apache-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Apache-1.0.json",
-      "referenceNumber": 597,
+      "referenceNumber": 675,
       "name": "Apache License 1.0",
       "licenseId": "Apache-1.0",
       "seeAlso": [
@@ -398,7 +425,7 @@
       "reference": "https://spdx.org/licenses/Apache-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Apache-1.1.json",
-      "referenceNumber": 15,
+      "referenceNumber": 100,
       "name": "Apache License 1.1",
       "licenseId": "Apache-1.1",
       "seeAlso": [
@@ -412,12 +439,13 @@
       "reference": "https://spdx.org/licenses/Apache-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Apache-2.0.json",
-      "referenceNumber": 611,
+      "referenceNumber": 289,
       "name": "Apache License 2.0",
       "licenseId": "Apache-2.0",
       "seeAlso": [
         "https://www.apache.org/licenses/LICENSE-2.0",
-        "https://opensource.org/licenses/Apache-2.0"
+        "https://opensource.org/licenses/Apache-2.0",
+        "https://opensource.org/license/apache-2-0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -426,7 +454,7 @@
       "reference": "https://spdx.org/licenses/APAFML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APAFML.json",
-      "referenceNumber": 83,
+      "referenceNumber": 390,
       "name": "Adobe Postscript AFM License",
       "licenseId": "APAFML",
       "seeAlso": [
@@ -438,7 +466,7 @@
       "reference": "https://spdx.org/licenses/APL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APL-1.0.json",
-      "referenceNumber": 539,
+      "referenceNumber": 392,
       "name": "Adaptive Public License 1.0",
       "licenseId": "APL-1.0",
       "seeAlso": [
@@ -450,7 +478,7 @@
       "reference": "https://spdx.org/licenses/App-s2p.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/App-s2p.json",
-      "referenceNumber": 282,
+      "referenceNumber": 367,
       "name": "App::s2p License",
       "licenseId": "App-s2p",
       "seeAlso": [
@@ -462,7 +490,7 @@
       "reference": "https://spdx.org/licenses/APSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APSL-1.0.json",
-      "referenceNumber": 45,
+      "referenceNumber": 540,
       "name": "Apple Public Source License 1.0",
       "licenseId": "APSL-1.0",
       "seeAlso": [
@@ -475,7 +503,7 @@
       "reference": "https://spdx.org/licenses/APSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APSL-1.1.json",
-      "referenceNumber": 133,
+      "referenceNumber": 682,
       "name": "Apple Public Source License 1.1",
       "licenseId": "APSL-1.1",
       "seeAlso": [
@@ -487,7 +515,7 @@
       "reference": "https://spdx.org/licenses/APSL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APSL-1.2.json",
-      "referenceNumber": 427,
+      "referenceNumber": 683,
       "name": "Apple Public Source License 1.2",
       "licenseId": "APSL-1.2",
       "seeAlso": [
@@ -499,7 +527,7 @@
       "reference": "https://spdx.org/licenses/APSL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APSL-2.0.json",
-      "referenceNumber": 119,
+      "referenceNumber": 692,
       "name": "Apple Public Source License 2.0",
       "licenseId": "APSL-2.0",
       "seeAlso": [
@@ -512,7 +540,7 @@
       "reference": "https://spdx.org/licenses/Arphic-1999.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Arphic-1999.json",
-      "referenceNumber": 508,
+      "referenceNumber": 547,
       "name": "Arphic Public License",
       "licenseId": "Arphic-1999",
       "seeAlso": [
@@ -524,7 +552,7 @@
       "reference": "https://spdx.org/licenses/Artistic-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Artistic-1.0.json",
-      "referenceNumber": 29,
+      "referenceNumber": 193,
       "name": "Artistic License 1.0",
       "licenseId": "Artistic-1.0",
       "seeAlso": [
@@ -537,7 +565,7 @@
       "reference": "https://spdx.org/licenses/Artistic-1.0-cl8.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Artistic-1.0-cl8.json",
-      "referenceNumber": 82,
+      "referenceNumber": 486,
       "name": "Artistic License 1.0 w/clause 8",
       "licenseId": "Artistic-1.0-cl8",
       "seeAlso": [
@@ -549,7 +577,7 @@
       "reference": "https://spdx.org/licenses/Artistic-1.0-Perl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Artistic-1.0-Perl.json",
-      "referenceNumber": 645,
+      "referenceNumber": 636,
       "name": "Artistic License 1.0 (Perl)",
       "licenseId": "Artistic-1.0-Perl",
       "seeAlso": [
@@ -561,7 +589,7 @@
       "reference": "https://spdx.org/licenses/Artistic-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Artistic-2.0.json",
-      "referenceNumber": 97,
+      "referenceNumber": 266,
       "name": "Artistic License 2.0",
       "licenseId": "Artistic-2.0",
       "seeAlso": [
@@ -573,10 +601,34 @@
       "isFsfLibre": true
     },
     {
+      "reference": "https://spdx.org/licenses/Artistic-dist.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Artistic-dist.json",
+      "referenceNumber": 615,
+      "name": "Artistic License 1.0 (dist)",
+      "licenseId": "Artistic-dist",
+      "seeAlso": [
+        "https://github.com/pexip/os-perl/blob/833cf4c86cc465ccfc627ff16db67e783156a248/debian/copyright#L2720-L2845"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Aspell-RU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Aspell-RU.json",
+      "referenceNumber": 335,
+      "name": "Aspell Russian License",
+      "licenseId": "Aspell-RU",
+      "seeAlso": [
+        "https://ftp.gnu.org/gnu/aspell/dict/ru/aspell6-ru-0.99f7-1.tar.bz2"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/ASWF-Digital-Assets-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ASWF-Digital-Assets-1.0.json",
-      "referenceNumber": 420,
+      "referenceNumber": 247,
       "name": "ASWF Digital Assets License version 1.0",
       "licenseId": "ASWF-Digital-Assets-1.0",
       "seeAlso": [
@@ -588,7 +640,7 @@
       "reference": "https://spdx.org/licenses/ASWF-Digital-Assets-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ASWF-Digital-Assets-1.1.json",
-      "referenceNumber": 314,
+      "referenceNumber": 23,
       "name": "ASWF Digital Assets License 1.1",
       "licenseId": "ASWF-Digital-Assets-1.1",
       "seeAlso": [
@@ -600,7 +652,7 @@
       "reference": "https://spdx.org/licenses/Baekmuk.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Baekmuk.json",
-      "referenceNumber": 451,
+      "referenceNumber": 219,
       "name": "Baekmuk License",
       "licenseId": "Baekmuk",
       "seeAlso": [
@@ -612,7 +664,7 @@
       "reference": "https://spdx.org/licenses/Bahyph.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Bahyph.json",
-      "referenceNumber": 608,
+      "referenceNumber": 435,
       "name": "Bahyph License",
       "licenseId": "Bahyph",
       "seeAlso": [
@@ -624,7 +676,7 @@
       "reference": "https://spdx.org/licenses/Barr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Barr.json",
-      "referenceNumber": 566,
+      "referenceNumber": 657,
       "name": "Barr License",
       "licenseId": "Barr",
       "seeAlso": [
@@ -636,7 +688,7 @@
       "reference": "https://spdx.org/licenses/bcrypt-Solar-Designer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/bcrypt-Solar-Designer.json",
-      "referenceNumber": 574,
+      "referenceNumber": 353,
       "name": "bcrypt Solar Designer License",
       "licenseId": "bcrypt-Solar-Designer",
       "seeAlso": [
@@ -648,7 +700,7 @@
       "reference": "https://spdx.org/licenses/Beerware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Beerware.json",
-      "referenceNumber": 105,
+      "referenceNumber": 38,
       "name": "Beerware License",
       "licenseId": "Beerware",
       "seeAlso": [
@@ -661,7 +713,7 @@
       "reference": "https://spdx.org/licenses/Bitstream-Charter.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Bitstream-Charter.json",
-      "referenceNumber": 464,
+      "referenceNumber": 228,
       "name": "Bitstream Charter Font License",
       "licenseId": "Bitstream-Charter",
       "seeAlso": [
@@ -674,7 +726,7 @@
       "reference": "https://spdx.org/licenses/Bitstream-Vera.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Bitstream-Vera.json",
-      "referenceNumber": 124,
+      "referenceNumber": 26,
       "name": "Bitstream Vera Font License",
       "licenseId": "Bitstream-Vera",
       "seeAlso": [
@@ -687,7 +739,7 @@
       "reference": "https://spdx.org/licenses/BitTorrent-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BitTorrent-1.0.json",
-      "referenceNumber": 405,
+      "referenceNumber": 663,
       "name": "BitTorrent Open Source License v1.0",
       "licenseId": "BitTorrent-1.0",
       "seeAlso": [
@@ -699,7 +751,7 @@
       "reference": "https://spdx.org/licenses/BitTorrent-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BitTorrent-1.1.json",
-      "referenceNumber": 248,
+      "referenceNumber": 292,
       "name": "BitTorrent Open Source License v1.1",
       "licenseId": "BitTorrent-1.1",
       "seeAlso": [
@@ -712,7 +764,7 @@
       "reference": "https://spdx.org/licenses/blessing.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/blessing.json",
-      "referenceNumber": 23,
+      "referenceNumber": 13,
       "name": "SQLite Blessing",
       "licenseId": "blessing",
       "seeAlso": [
@@ -725,7 +777,7 @@
       "reference": "https://spdx.org/licenses/BlueOak-1.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BlueOak-1.0.0.json",
-      "referenceNumber": 95,
+      "referenceNumber": 425,
       "name": "Blue Oak Model License 1.0.0",
       "licenseId": "BlueOak-1.0.0",
       "seeAlso": [
@@ -737,7 +789,7 @@
       "reference": "https://spdx.org/licenses/Boehm-GC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Boehm-GC.json",
-      "referenceNumber": 580,
+      "referenceNumber": 368,
       "name": "Boehm-Demers-Weiser GC License",
       "licenseId": "Boehm-GC",
       "seeAlso": [
@@ -748,10 +800,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/Boehm-GC-without-fee.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Boehm-GC-without-fee.json",
+      "referenceNumber": 621,
+      "name": "Boehm-Demers-Weiser GC License (without fee)",
+      "licenseId": "Boehm-GC-without-fee",
+      "seeAlso": [
+        "https://github.com/MariaDB/server/blob/11.6/libmysqld/lib_sql.cc"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/Borceux.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Borceux.json",
-      "referenceNumber": 141,
+      "referenceNumber": 617,
       "name": "Borceux license",
       "licenseId": "Borceux",
       "seeAlso": [
@@ -763,7 +827,7 @@
       "reference": "https://spdx.org/licenses/Brian-Gladman-2-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Brian-Gladman-2-Clause.json",
-      "referenceNumber": 106,
+      "referenceNumber": 426,
       "name": "Brian Gladman 2-Clause License",
       "licenseId": "Brian-Gladman-2-Clause",
       "seeAlso": [
@@ -776,7 +840,7 @@
       "reference": "https://spdx.org/licenses/Brian-Gladman-3-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Brian-Gladman-3-Clause.json",
-      "referenceNumber": 612,
+      "referenceNumber": 415,
       "name": "Brian Gladman 3-Clause License",
       "licenseId": "Brian-Gladman-3-Clause",
       "seeAlso": [
@@ -788,7 +852,7 @@
       "reference": "https://spdx.org/licenses/BSD-1-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-1-Clause.json",
-      "referenceNumber": 225,
+      "referenceNumber": 196,
       "name": "BSD 1-Clause License",
       "licenseId": "BSD-1-Clause",
       "seeAlso": [
@@ -800,7 +864,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause.json",
-      "referenceNumber": 136,
+      "referenceNumber": 613,
       "name": "BSD 2-Clause \"Simplified\" License",
       "licenseId": "BSD-2-Clause",
       "seeAlso": [
@@ -813,7 +877,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-Darwin.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Darwin.json",
-      "referenceNumber": 641,
+      "referenceNumber": 92,
       "name": "BSD 2-Clause - Ian Darwin variant",
       "licenseId": "BSD-2-Clause-Darwin",
       "seeAlso": [
@@ -822,12 +886,12 @@
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/BSD-2-clause-first-lines.html",
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-first-lines.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-2-clause-first-lines.json",
-      "referenceNumber": 351,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-first-lines.json",
+      "referenceNumber": 80,
       "name": "BSD 2-Clause - first lines requirement",
-      "licenseId": "BSD-2-clause-first-lines",
+      "licenseId": "BSD-2-Clause-first-lines",
       "seeAlso": [
         "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L664-L690",
         "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
@@ -838,7 +902,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-FreeBSD.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-FreeBSD.json",
-      "referenceNumber": 247,
+      "referenceNumber": 221,
       "name": "BSD 2-Clause FreeBSD License",
       "licenseId": "BSD-2-Clause-FreeBSD",
       "seeAlso": [
@@ -851,7 +915,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-NetBSD.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-NetBSD.json",
-      "referenceNumber": 522,
+      "referenceNumber": 25,
       "name": "BSD 2-Clause NetBSD License",
       "licenseId": "BSD-2-Clause-NetBSD",
       "seeAlso": [
@@ -864,7 +928,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-Patent.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Patent.json",
-      "referenceNumber": 478,
+      "referenceNumber": 356,
       "name": "BSD-2-Clause Plus Patent License",
       "licenseId": "BSD-2-Clause-Patent",
       "seeAlso": [
@@ -873,10 +937,23 @@
       "isOsiApproved": true
     },
     {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-pkgconf-disclaimer.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-pkgconf-disclaimer.json",
+      "referenceNumber": 331,
+      "name": "BSD 2-Clause pkgconf disclaimer variant",
+      "licenseId": "BSD-2-Clause-pkgconf-disclaimer",
+      "seeAlso": [
+        "https://github.com/audacious-media-player/audacious/blob/master/src/audacious/main.cc",
+        "https://github.com/audacious-media-player/audacious/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/BSD-2-Clause-Views.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Views.json",
-      "referenceNumber": 644,
+      "referenceNumber": 695,
       "name": "BSD 2-Clause with views sentence",
       "licenseId": "BSD-2-Clause-Views",
       "seeAlso": [
@@ -890,7 +967,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause.json",
-      "referenceNumber": 419,
+      "referenceNumber": 624,
       "name": "BSD 3-Clause \"New\" or \"Revised\" License",
       "licenseId": "BSD-3-Clause",
       "seeAlso": [
@@ -904,7 +981,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-acpica.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-acpica.json",
-      "referenceNumber": 430,
+      "referenceNumber": 476,
       "name": "BSD 3-Clause acpica variant",
       "licenseId": "BSD-3-Clause-acpica",
       "seeAlso": [
@@ -916,7 +993,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Attribution.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Attribution.json",
-      "referenceNumber": 402,
+      "referenceNumber": 147,
       "name": "BSD with attribution",
       "licenseId": "BSD-3-Clause-Attribution",
       "seeAlso": [
@@ -928,7 +1005,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Clear.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Clear.json",
-      "referenceNumber": 55,
+      "referenceNumber": 521,
       "name": "BSD 3-Clause Clear License",
       "licenseId": "BSD-3-Clause-Clear",
       "seeAlso": [
@@ -941,7 +1018,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-flex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-flex.json",
-      "referenceNumber": 316,
+      "referenceNumber": 647,
       "name": "BSD 3-Clause Flex variant",
       "licenseId": "BSD-3-Clause-flex",
       "seeAlso": [
@@ -953,7 +1030,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-HP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-HP.json",
-      "referenceNumber": 584,
+      "referenceNumber": 7,
       "name": "Hewlett-Packard BSD variant license",
       "licenseId": "BSD-3-Clause-HP",
       "seeAlso": [
@@ -965,7 +1042,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-LBNL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-LBNL.json",
-      "referenceNumber": 88,
+      "referenceNumber": 31,
       "name": "Lawrence Berkeley National Labs BSD variant license",
       "licenseId": "BSD-3-Clause-LBNL",
       "seeAlso": [
@@ -977,7 +1054,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Modification.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Modification.json",
-      "referenceNumber": 514,
+      "referenceNumber": 17,
       "name": "BSD 3-Clause Modification",
       "licenseId": "BSD-3-Clause-Modification",
       "seeAlso": [
@@ -989,7 +1066,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.json",
-      "referenceNumber": 589,
+      "referenceNumber": 192,
       "name": "BSD 3-Clause No Military License",
       "licenseId": "BSD-3-Clause-No-Military-License",
       "seeAlso": [
@@ -1002,7 +1079,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.json",
-      "referenceNumber": 277,
+      "referenceNumber": 321,
       "name": "BSD 3-Clause No Nuclear License",
       "licenseId": "BSD-3-Clause-No-Nuclear-License",
       "seeAlso": [
@@ -1014,7 +1091,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
-      "referenceNumber": 463,
+      "referenceNumber": 508,
       "name": "BSD 3-Clause No Nuclear License 2014",
       "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
       "seeAlso": [
@@ -1026,7 +1103,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.json",
-      "referenceNumber": 547,
+      "referenceNumber": 350,
       "name": "BSD 3-Clause No Nuclear Warranty",
       "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
       "seeAlso": [
@@ -1038,7 +1115,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Open-MPI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Open-MPI.json",
-      "referenceNumber": 272,
+      "referenceNumber": 691,
       "name": "BSD 3-Clause Open MPI variant",
       "licenseId": "BSD-3-Clause-Open-MPI",
       "seeAlso": [
@@ -1051,7 +1128,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Sun.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Sun.json",
-      "referenceNumber": 283,
+      "referenceNumber": 116,
       "name": "BSD 3-Clause Sun Microsystems",
       "licenseId": "BSD-3-Clause-Sun",
       "seeAlso": [
@@ -1060,10 +1137,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-Tso.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Tso.json",
+      "referenceNumber": 179,
+      "name": "BSD 3-Clause Tso variant",
+      "licenseId": "BSD-3-Clause-Tso",
+      "seeAlso": [
+        "https://www.x.org/archive/current/doc/xorg-docs/License.html#Theodore_Tso"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/BSD-4-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause.json",
-      "referenceNumber": 650,
+      "referenceNumber": 660,
       "name": "BSD 4-Clause \"Original\" or \"Old\" License",
       "licenseId": "BSD-4-Clause",
       "seeAlso": [
@@ -1076,7 +1165,7 @@
       "reference": "https://spdx.org/licenses/BSD-4-Clause-Shortened.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause-Shortened.json",
-      "referenceNumber": 180,
+      "referenceNumber": 139,
       "name": "BSD 4 Clause Shortened",
       "licenseId": "BSD-4-Clause-Shortened",
       "seeAlso": [
@@ -1088,7 +1177,7 @@
       "reference": "https://spdx.org/licenses/BSD-4-Clause-UC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause-UC.json",
-      "referenceNumber": 380,
+      "referenceNumber": 563,
       "name": "BSD-4-Clause (University of California-Specific)",
       "licenseId": "BSD-4-Clause-UC",
       "seeAlso": [
@@ -1100,7 +1189,7 @@
       "reference": "https://spdx.org/licenses/BSD-4.3RENO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4.3RENO.json",
-      "referenceNumber": 72,
+      "referenceNumber": 133,
       "name": "BSD 4.3 RENO License",
       "licenseId": "BSD-4.3RENO",
       "seeAlso": [
@@ -1113,7 +1202,7 @@
       "reference": "https://spdx.org/licenses/BSD-4.3TAHOE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4.3TAHOE.json",
-      "referenceNumber": 453,
+      "referenceNumber": 213,
       "name": "BSD 4.3 TAHOE License",
       "licenseId": "BSD-4.3TAHOE",
       "seeAlso": [
@@ -1126,7 +1215,7 @@
       "reference": "https://spdx.org/licenses/BSD-Advertising-Acknowledgement.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Advertising-Acknowledgement.json",
-      "referenceNumber": 591,
+      "referenceNumber": 345,
       "name": "BSD Advertising Acknowledgement License",
       "licenseId": "BSD-Advertising-Acknowledgement",
       "seeAlso": [
@@ -1138,7 +1227,7 @@
       "reference": "https://spdx.org/licenses/BSD-Attribution-HPND-disclaimer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Attribution-HPND-disclaimer.json",
-      "referenceNumber": 148,
+      "referenceNumber": 565,
       "name": "BSD with Attribution and HPND disclaimer",
       "licenseId": "BSD-Attribution-HPND-disclaimer",
       "seeAlso": [
@@ -1150,7 +1239,7 @@
       "reference": "https://spdx.org/licenses/BSD-Inferno-Nettverk.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Inferno-Nettverk.json",
-      "referenceNumber": 215,
+      "referenceNumber": 681,
       "name": "BSD-Inferno-Nettverk",
       "licenseId": "BSD-Inferno-Nettverk",
       "seeAlso": [
@@ -1162,7 +1251,7 @@
       "reference": "https://spdx.org/licenses/BSD-Protection.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Protection.json",
-      "referenceNumber": 616,
+      "referenceNumber": 224,
       "name": "BSD Protection License",
       "licenseId": "BSD-Protection",
       "seeAlso": [
@@ -1174,7 +1263,7 @@
       "reference": "https://spdx.org/licenses/BSD-Source-beginning-file.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Source-beginning-file.json",
-      "referenceNumber": 68,
+      "referenceNumber": 190,
       "name": "BSD Source Code Attribution - beginning of file variant",
       "licenseId": "BSD-Source-beginning-file",
       "seeAlso": [
@@ -1186,7 +1275,7 @@
       "reference": "https://spdx.org/licenses/BSD-Source-Code.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Source-Code.json",
-      "referenceNumber": 599,
+      "referenceNumber": 175,
       "name": "BSD Source Code Attribution",
       "licenseId": "BSD-Source-Code",
       "seeAlso": [
@@ -1198,7 +1287,7 @@
       "reference": "https://spdx.org/licenses/BSD-Systemics.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Systemics.json",
-      "referenceNumber": 452,
+      "referenceNumber": 156,
       "name": "Systemics BSD variant license",
       "licenseId": "BSD-Systemics",
       "seeAlso": [
@@ -1210,7 +1299,7 @@
       "reference": "https://spdx.org/licenses/BSD-Systemics-W3Works.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Systemics-W3Works.json",
-      "referenceNumber": 299,
+      "referenceNumber": 263,
       "name": "Systemics W3Works BSD variant license",
       "licenseId": "BSD-Systemics-W3Works",
       "seeAlso": [
@@ -1222,7 +1311,7 @@
       "reference": "https://spdx.org/licenses/BSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSL-1.0.json",
-      "referenceNumber": 359,
+      "referenceNumber": 545,
       "name": "Boost Software License 1.0",
       "licenseId": "BSL-1.0",
       "seeAlso": [
@@ -1236,7 +1325,7 @@
       "reference": "https://spdx.org/licenses/BUSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BUSL-1.1.json",
-      "referenceNumber": 336,
+      "referenceNumber": 537,
       "name": "Business Source License 1.1",
       "licenseId": "BUSL-1.1",
       "seeAlso": [
@@ -1248,7 +1337,7 @@
       "reference": "https://spdx.org/licenses/bzip2-1.0.5.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/bzip2-1.0.5.json",
-      "referenceNumber": 553,
+      "referenceNumber": 463,
       "name": "bzip2 and libbzip2 License v1.0.5",
       "licenseId": "bzip2-1.0.5",
       "seeAlso": [
@@ -1261,7 +1350,7 @@
       "reference": "https://spdx.org/licenses/bzip2-1.0.6.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/bzip2-1.0.6.json",
-      "referenceNumber": 62,
+      "referenceNumber": 359,
       "name": "bzip2 and libbzip2 License v1.0.6",
       "licenseId": "bzip2-1.0.6",
       "seeAlso": [
@@ -1275,7 +1364,7 @@
       "reference": "https://spdx.org/licenses/C-UDA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/C-UDA-1.0.json",
-      "referenceNumber": 403,
+      "referenceNumber": 307,
       "name": "Computational Use of Data Agreement v1.0",
       "licenseId": "C-UDA-1.0",
       "seeAlso": [
@@ -1288,7 +1377,7 @@
       "reference": "https://spdx.org/licenses/CAL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CAL-1.0.json",
-      "referenceNumber": 550,
+      "referenceNumber": 40,
       "name": "Cryptographic Autonomy License 1.0",
       "licenseId": "CAL-1.0",
       "seeAlso": [
@@ -1301,7 +1390,7 @@
       "reference": "https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.json",
-      "referenceNumber": 28,
+      "referenceNumber": 491,
       "name": "Cryptographic Autonomy License 1.0 (Combined Work Exception)",
       "licenseId": "CAL-1.0-Combined-Work-Exception",
       "seeAlso": [
@@ -1314,7 +1403,7 @@
       "reference": "https://spdx.org/licenses/Caldera.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Caldera.json",
-      "referenceNumber": 81,
+      "referenceNumber": 632,
       "name": "Caldera License",
       "licenseId": "Caldera",
       "seeAlso": [
@@ -1326,7 +1415,7 @@
       "reference": "https://spdx.org/licenses/Caldera-no-preamble.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Caldera-no-preamble.json",
-      "referenceNumber": 257,
+      "referenceNumber": 697,
       "name": "Caldera License (without preamble)",
       "licenseId": "Caldera-no-preamble",
       "seeAlso": [
@@ -1338,7 +1427,7 @@
       "reference": "https://spdx.org/licenses/Catharon.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Catharon.json",
-      "referenceNumber": 532,
+      "referenceNumber": 598,
       "name": "Catharon License",
       "licenseId": "Catharon",
       "seeAlso": [
@@ -1350,7 +1439,7 @@
       "reference": "https://spdx.org/licenses/CATOSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CATOSL-1.1.json",
-      "referenceNumber": 278,
+      "referenceNumber": 51,
       "name": "Computer Associates Trusted Open Source License 1.1",
       "licenseId": "CATOSL-1.1",
       "seeAlso": [
@@ -1362,7 +1451,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-1.0.json",
-      "referenceNumber": 399,
+      "referenceNumber": 457,
       "name": "Creative Commons Attribution 1.0 Generic",
       "licenseId": "CC-BY-1.0",
       "seeAlso": [
@@ -1374,7 +1463,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-2.0.json",
-      "referenceNumber": 423,
+      "referenceNumber": 0,
       "name": "Creative Commons Attribution 2.0 Generic",
       "licenseId": "CC-BY-2.0",
       "seeAlso": [
@@ -1386,7 +1475,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-2.5.json",
-      "referenceNumber": 373,
+      "referenceNumber": 155,
       "name": "Creative Commons Attribution 2.5 Generic",
       "licenseId": "CC-BY-2.5",
       "seeAlso": [
@@ -1398,7 +1487,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-2.5-AU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-2.5-AU.json",
-      "referenceNumber": 429,
+      "referenceNumber": 12,
       "name": "Creative Commons Attribution 2.5 Australia",
       "licenseId": "CC-BY-2.5-AU",
       "seeAlso": [
@@ -1410,7 +1499,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0.json",
-      "referenceNumber": 535,
+      "referenceNumber": 483,
       "name": "Creative Commons Attribution 3.0 Unported",
       "licenseId": "CC-BY-3.0",
       "seeAlso": [
@@ -1422,7 +1511,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-AT.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-AT.json",
-      "referenceNumber": 236,
+      "referenceNumber": 381,
       "name": "Creative Commons Attribution 3.0 Austria",
       "licenseId": "CC-BY-3.0-AT",
       "seeAlso": [
@@ -1434,7 +1523,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-AU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-AU.json",
-      "referenceNumber": 77,
+      "referenceNumber": 468,
       "name": "Creative Commons Attribution 3.0 Australia",
       "licenseId": "CC-BY-3.0-AU",
       "seeAlso": [
@@ -1446,7 +1535,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-DE.json",
-      "referenceNumber": 349,
+      "referenceNumber": 218,
       "name": "Creative Commons Attribution 3.0 Germany",
       "licenseId": "CC-BY-3.0-DE",
       "seeAlso": [
@@ -1458,7 +1547,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-IGO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-IGO.json",
-      "referenceNumber": 173,
+      "referenceNumber": 385,
       "name": "Creative Commons Attribution 3.0 IGO",
       "licenseId": "CC-BY-3.0-IGO",
       "seeAlso": [
@@ -1470,7 +1559,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-NL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-NL.json",
-      "referenceNumber": 135,
+      "referenceNumber": 246,
       "name": "Creative Commons Attribution 3.0 Netherlands",
       "licenseId": "CC-BY-3.0-NL",
       "seeAlso": [
@@ -1482,7 +1571,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-US.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-US.json",
-      "referenceNumber": 317,
+      "referenceNumber": 387,
       "name": "Creative Commons Attribution 3.0 United States",
       "licenseId": "CC-BY-3.0-US",
       "seeAlso": [
@@ -1494,7 +1583,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-4.0.json",
-      "referenceNumber": 231,
+      "referenceNumber": 79,
       "name": "Creative Commons Attribution 4.0 International",
       "licenseId": "CC-BY-4.0",
       "seeAlso": [
@@ -1507,7 +1596,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-1.0.json",
-      "referenceNumber": 397,
+      "referenceNumber": 492,
       "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
       "licenseId": "CC-BY-NC-1.0",
       "seeAlso": [
@@ -1520,7 +1609,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-2.0.json",
-      "referenceNumber": 91,
+      "referenceNumber": 447,
       "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
       "licenseId": "CC-BY-NC-2.0",
       "seeAlso": [
@@ -1533,7 +1622,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-2.5.json",
-      "referenceNumber": 92,
+      "referenceNumber": 614,
       "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
       "licenseId": "CC-BY-NC-2.5",
       "seeAlso": [
@@ -1546,7 +1635,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0.json",
-      "referenceNumber": 475,
+      "referenceNumber": 567,
       "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
       "licenseId": "CC-BY-NC-3.0",
       "seeAlso": [
@@ -1559,7 +1648,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0-DE.json",
-      "referenceNumber": 474,
+      "referenceNumber": 403,
       "name": "Creative Commons Attribution Non Commercial 3.0 Germany",
       "licenseId": "CC-BY-NC-3.0-DE",
       "seeAlso": [
@@ -1571,7 +1660,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-4.0.json",
-      "referenceNumber": 324,
+      "referenceNumber": 161,
       "name": "Creative Commons Attribution Non Commercial 4.0 International",
       "licenseId": "CC-BY-NC-4.0",
       "seeAlso": [
@@ -1584,7 +1673,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-1.0.json",
-      "referenceNumber": 617,
+      "referenceNumber": 453,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-NC-ND-1.0",
       "seeAlso": [
@@ -1596,7 +1685,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-2.0.json",
-      "referenceNumber": 379,
+      "referenceNumber": 167,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-NC-ND-2.0",
       "seeAlso": [
@@ -1608,7 +1697,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-2.5.json",
-      "referenceNumber": 527,
+      "referenceNumber": 464,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-NC-ND-2.5",
       "seeAlso": [
@@ -1620,7 +1709,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.json",
-      "referenceNumber": 252,
+      "referenceNumber": 259,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-NC-ND-3.0",
       "seeAlso": [
@@ -1632,7 +1721,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.json",
-      "referenceNumber": 38,
+      "referenceNumber": 641,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany",
       "licenseId": "CC-BY-NC-ND-3.0-DE",
       "seeAlso": [
@@ -1644,7 +1733,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.json",
-      "referenceNumber": 193,
+      "referenceNumber": 608,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO",
       "licenseId": "CC-BY-NC-ND-3.0-IGO",
       "seeAlso": [
@@ -1656,7 +1745,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
-      "referenceNumber": 279,
+      "referenceNumber": 215,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
       "licenseId": "CC-BY-NC-ND-4.0",
       "seeAlso": [
@@ -1668,7 +1757,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-1.0.json",
-      "referenceNumber": 433,
+      "referenceNumber": 250,
       "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
       "licenseId": "CC-BY-NC-SA-1.0",
       "seeAlso": [
@@ -1680,7 +1769,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0.json",
-      "referenceNumber": 260,
+      "referenceNumber": 78,
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
       "licenseId": "CC-BY-NC-SA-2.0",
       "seeAlso": [
@@ -1692,7 +1781,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-DE.json",
-      "referenceNumber": 281,
+      "referenceNumber": 649,
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Germany",
       "licenseId": "CC-BY-NC-SA-2.0-DE",
       "seeAlso": [
@@ -1704,7 +1793,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.json",
-      "referenceNumber": 185,
+      "referenceNumber": 416,
       "name": "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France",
       "licenseId": "CC-BY-NC-SA-2.0-FR",
       "seeAlso": [
@@ -1716,7 +1805,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.json",
-      "referenceNumber": 230,
+      "referenceNumber": 430,
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales",
       "licenseId": "CC-BY-NC-SA-2.0-UK",
       "seeAlso": [
@@ -1728,7 +1817,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.5.json",
-      "referenceNumber": 640,
+      "referenceNumber": 49,
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
       "licenseId": "CC-BY-NC-SA-2.5",
       "seeAlso": [
@@ -1740,7 +1829,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.json",
-      "referenceNumber": 191,
+      "referenceNumber": 339,
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
       "licenseId": "CC-BY-NC-SA-3.0",
       "seeAlso": [
@@ -1752,7 +1841,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.json",
-      "referenceNumber": 5,
+      "referenceNumber": 200,
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Germany",
       "licenseId": "CC-BY-NC-SA-3.0-DE",
       "seeAlso": [
@@ -1764,7 +1853,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.json",
-      "referenceNumber": 59,
+      "referenceNumber": 46,
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 IGO",
       "licenseId": "CC-BY-NC-SA-3.0-IGO",
       "seeAlso": [
@@ -1776,7 +1865,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
-      "referenceNumber": 521,
+      "referenceNumber": 151,
       "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
       "licenseId": "CC-BY-NC-SA-4.0",
       "seeAlso": [
@@ -1788,7 +1877,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-1.0.json",
-      "referenceNumber": 76,
+      "referenceNumber": 661,
       "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-ND-1.0",
       "seeAlso": [
@@ -1801,7 +1890,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-2.0.json",
-      "referenceNumber": 242,
+      "referenceNumber": 380,
       "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-ND-2.0",
       "seeAlso": [
@@ -1814,7 +1903,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-2.5.json",
-      "referenceNumber": 134,
+      "referenceNumber": 551,
       "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-ND-2.5",
       "seeAlso": [
@@ -1827,7 +1916,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-3.0.json",
-      "referenceNumber": 181,
+      "referenceNumber": 52,
       "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-ND-3.0",
       "seeAlso": [
@@ -1840,7 +1929,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-3.0-DE.json",
-      "referenceNumber": 98,
+      "referenceNumber": 59,
       "name": "Creative Commons Attribution No Derivatives 3.0 Germany",
       "licenseId": "CC-BY-ND-3.0-DE",
       "seeAlso": [
@@ -1852,7 +1941,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-4.0.json",
-      "referenceNumber": 322,
+      "referenceNumber": 348,
       "name": "Creative Commons Attribution No Derivatives 4.0 International",
       "licenseId": "CC-BY-ND-4.0",
       "seeAlso": [
@@ -1865,7 +1954,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-1.0.json",
-      "referenceNumber": 564,
+      "referenceNumber": 569,
       "name": "Creative Commons Attribution Share Alike 1.0 Generic",
       "licenseId": "CC-BY-SA-1.0",
       "seeAlso": [
@@ -1877,7 +1966,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.0.json",
-      "referenceNumber": 74,
+      "referenceNumber": 656,
       "name": "Creative Commons Attribution Share Alike 2.0 Generic",
       "licenseId": "CC-BY-SA-2.0",
       "seeAlso": [
@@ -1889,7 +1978,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-2.0-UK.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.0-UK.json",
-      "referenceNumber": 35,
+      "referenceNumber": 585,
       "name": "Creative Commons Attribution Share Alike 2.0 England and Wales",
       "licenseId": "CC-BY-SA-2.0-UK",
       "seeAlso": [
@@ -1901,7 +1990,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-2.1-JP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.1-JP.json",
-      "referenceNumber": 636,
+      "referenceNumber": 370,
       "name": "Creative Commons Attribution Share Alike 2.1 Japan",
       "licenseId": "CC-BY-SA-2.1-JP",
       "seeAlso": [
@@ -1913,7 +2002,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.5.json",
-      "referenceNumber": 33,
+      "referenceNumber": 474,
       "name": "Creative Commons Attribution Share Alike 2.5 Generic",
       "licenseId": "CC-BY-SA-2.5",
       "seeAlso": [
@@ -1925,7 +2014,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0.json",
-      "referenceNumber": 3,
+      "referenceNumber": 131,
       "name": "Creative Commons Attribution Share Alike 3.0 Unported",
       "licenseId": "CC-BY-SA-3.0",
       "seeAlso": [
@@ -1937,7 +2026,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-AT.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-AT.json",
-      "referenceNumber": 362,
+      "referenceNumber": 361,
       "name": "Creative Commons Attribution Share Alike 3.0 Austria",
       "licenseId": "CC-BY-SA-3.0-AT",
       "seeAlso": [
@@ -1949,7 +2038,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-DE.json",
-      "referenceNumber": 9,
+      "referenceNumber": 160,
       "name": "Creative Commons Attribution Share Alike 3.0 Germany",
       "licenseId": "CC-BY-SA-3.0-DE",
       "seeAlso": [
@@ -1961,7 +2050,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-IGO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-IGO.json",
-      "referenceNumber": 424,
+      "referenceNumber": 141,
       "name": "Creative Commons Attribution-ShareAlike 3.0 IGO",
       "licenseId": "CC-BY-SA-3.0-IGO",
       "seeAlso": [
@@ -1973,7 +2062,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-4.0.json",
-      "referenceNumber": 201,
+      "referenceNumber": 328,
       "name": "Creative Commons Attribution Share Alike 4.0 International",
       "licenseId": "CC-BY-SA-4.0",
       "seeAlso": [
@@ -1986,7 +2075,7 @@
       "reference": "https://spdx.org/licenses/CC-PDDC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-PDDC.json",
-      "referenceNumber": 213,
+      "referenceNumber": 599,
       "name": "Creative Commons Public Domain Dedication and Certification",
       "licenseId": "CC-PDDC",
       "seeAlso": [
@@ -1995,10 +2084,35 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/CC-PDM-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-PDM-1.0.json",
+      "referenceNumber": 594,
+      "name": "Creative    Commons Public Domain Mark 1.0 Universal",
+      "licenseId": "CC-PDM-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/publicdomain/mark/1.0/",
+        "https://creativecommons.org/share-your-work/cclicenses/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-SA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-SA-1.0.json",
+      "referenceNumber": 293,
+      "name": "Creative Commons Share Alike 1.0 Generic",
+      "licenseId": "CC-SA-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/sa/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/CC0-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC0-1.0.json",
-      "referenceNumber": 301,
+      "referenceNumber": 185,
       "name": "Creative Commons Zero v1.0 Universal",
       "licenseId": "CC0-1.0",
       "seeAlso": [
@@ -2011,7 +2125,7 @@
       "reference": "https://spdx.org/licenses/CDDL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDDL-1.0.json",
-      "referenceNumber": 89,
+      "referenceNumber": 211,
       "name": "Common Development and Distribution License 1.0",
       "licenseId": "CDDL-1.0",
       "seeAlso": [
@@ -2024,7 +2138,7 @@
       "reference": "https://spdx.org/licenses/CDDL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDDL-1.1.json",
-      "referenceNumber": 266,
+      "referenceNumber": 371,
       "name": "Common Development and Distribution License 1.1",
       "licenseId": "CDDL-1.1",
       "seeAlso": [
@@ -2037,7 +2151,7 @@
       "reference": "https://spdx.org/licenses/CDL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDL-1.0.json",
-      "referenceNumber": 261,
+      "referenceNumber": 194,
       "name": "Common Documentation License 1.0",
       "licenseId": "CDL-1.0",
       "seeAlso": [
@@ -2051,7 +2165,7 @@
       "reference": "https://spdx.org/licenses/CDLA-Permissive-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDLA-Permissive-1.0.json",
-      "referenceNumber": 504,
+      "referenceNumber": 422,
       "name": "Community Data License Agreement Permissive 1.0",
       "licenseId": "CDLA-Permissive-1.0",
       "seeAlso": [
@@ -2063,7 +2177,7 @@
       "reference": "https://spdx.org/licenses/CDLA-Permissive-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDLA-Permissive-2.0.json",
-      "referenceNumber": 47,
+      "referenceNumber": 136,
       "name": "Community Data License Agreement Permissive 2.0",
       "licenseId": "CDLA-Permissive-2.0",
       "seeAlso": [
@@ -2075,7 +2189,7 @@
       "reference": "https://spdx.org/licenses/CDLA-Sharing-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDLA-Sharing-1.0.json",
-      "referenceNumber": 270,
+      "referenceNumber": 74,
       "name": "Community Data License Agreement Sharing 1.0",
       "licenseId": "CDLA-Sharing-1.0",
       "seeAlso": [
@@ -2087,7 +2201,7 @@
       "reference": "https://spdx.org/licenses/CECILL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-1.0.json",
-      "referenceNumber": 222,
+      "referenceNumber": 1,
       "name": "CeCILL Free Software License Agreement v1.0",
       "licenseId": "CECILL-1.0",
       "seeAlso": [
@@ -2099,7 +2213,7 @@
       "reference": "https://spdx.org/licenses/CECILL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-1.1.json",
-      "referenceNumber": 357,
+      "referenceNumber": 50,
       "name": "CeCILL Free Software License Agreement v1.1",
       "licenseId": "CECILL-1.1",
       "seeAlso": [
@@ -2111,7 +2225,7 @@
       "reference": "https://spdx.org/licenses/CECILL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-2.0.json",
-      "referenceNumber": 86,
+      "referenceNumber": 662,
       "name": "CeCILL Free Software License Agreement v2.0",
       "licenseId": "CECILL-2.0",
       "seeAlso": [
@@ -2124,7 +2238,7 @@
       "reference": "https://spdx.org/licenses/CECILL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-2.1.json",
-      "referenceNumber": 371,
+      "referenceNumber": 431,
       "name": "CeCILL Free Software License Agreement v2.1",
       "licenseId": "CECILL-2.1",
       "seeAlso": [
@@ -2136,7 +2250,7 @@
       "reference": "https://spdx.org/licenses/CECILL-B.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-B.json",
-      "referenceNumber": 263,
+      "referenceNumber": 501,
       "name": "CeCILL-B Free Software License Agreement",
       "licenseId": "CECILL-B",
       "seeAlso": [
@@ -2149,7 +2263,7 @@
       "reference": "https://spdx.org/licenses/CECILL-C.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-C.json",
-      "referenceNumber": 320,
+      "referenceNumber": 555,
       "name": "CeCILL-C Free Software License Agreement",
       "licenseId": "CECILL-C",
       "seeAlso": [
@@ -2162,7 +2276,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-1.1.json",
-      "referenceNumber": 41,
+      "referenceNumber": 640,
       "name": "CERN Open Hardware Licence v1.1",
       "licenseId": "CERN-OHL-1.1",
       "seeAlso": [
@@ -2174,7 +2288,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-1.2.json",
-      "referenceNumber": 32,
+      "referenceNumber": 254,
       "name": "CERN Open Hardware Licence v1.2",
       "licenseId": "CERN-OHL-1.2",
       "seeAlso": [
@@ -2186,7 +2300,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-P-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-P-2.0.json",
-      "referenceNumber": 411,
+      "referenceNumber": 631,
       "name": "CERN Open Hardware Licence Version 2 - Permissive",
       "licenseId": "CERN-OHL-P-2.0",
       "seeAlso": [
@@ -2198,7 +2312,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-S-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-S-2.0.json",
-      "referenceNumber": 78,
+      "referenceNumber": 273,
       "name": "CERN Open Hardware Licence Version 2 - Strongly Reciprocal",
       "licenseId": "CERN-OHL-S-2.0",
       "seeAlso": [
@@ -2210,7 +2324,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-W-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-W-2.0.json",
-      "referenceNumber": 104,
+      "referenceNumber": 638,
       "name": "CERN Open Hardware Licence Version 2 - Weakly Reciprocal",
       "licenseId": "CERN-OHL-W-2.0",
       "seeAlso": [
@@ -2222,7 +2336,7 @@
       "reference": "https://spdx.org/licenses/CFITSIO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CFITSIO.json",
-      "referenceNumber": 228,
+      "referenceNumber": 162,
       "name": "CFITSIO License",
       "licenseId": "CFITSIO",
       "seeAlso": [
@@ -2235,7 +2349,7 @@
       "reference": "https://spdx.org/licenses/check-cvs.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/check-cvs.json",
-      "referenceNumber": 540,
+      "referenceNumber": 124,
       "name": "check-cvs License",
       "licenseId": "check-cvs",
       "seeAlso": [
@@ -2247,7 +2361,7 @@
       "reference": "https://spdx.org/licenses/checkmk.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/checkmk.json",
-      "referenceNumber": 610,
+      "referenceNumber": 558,
       "name": "Checkmk License",
       "licenseId": "checkmk",
       "seeAlso": [
@@ -2259,7 +2373,7 @@
       "reference": "https://spdx.org/licenses/ClArtistic.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ClArtistic.json",
-      "referenceNumber": 412,
+      "referenceNumber": 209,
       "name": "Clarified Artistic License",
       "licenseId": "ClArtistic",
       "seeAlso": [
@@ -2273,7 +2387,7 @@
       "reference": "https://spdx.org/licenses/Clips.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Clips.json",
-      "referenceNumber": 472,
+      "referenceNumber": 274,
       "name": "Clips License",
       "licenseId": "Clips",
       "seeAlso": [
@@ -2285,7 +2399,7 @@
       "reference": "https://spdx.org/licenses/CMU-Mach.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CMU-Mach.json",
-      "referenceNumber": 601,
+      "referenceNumber": 676,
       "name": "CMU Mach License",
       "licenseId": "CMU-Mach",
       "seeAlso": [
@@ -2297,7 +2411,7 @@
       "reference": "https://spdx.org/licenses/CMU-Mach-nodoc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CMU-Mach-nodoc.json",
-      "referenceNumber": 154,
+      "referenceNumber": 436,
       "name": "CMU    Mach - no notices-in-documentation variant",
       "licenseId": "CMU-Mach-nodoc",
       "seeAlso": [
@@ -2310,7 +2424,7 @@
       "reference": "https://spdx.org/licenses/CNRI-Jython.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CNRI-Jython.json",
-      "referenceNumber": 151,
+      "referenceNumber": 101,
       "name": "CNRI Jython License",
       "licenseId": "CNRI-Jython",
       "seeAlso": [
@@ -2322,7 +2436,7 @@
       "reference": "https://spdx.org/licenses/CNRI-Python.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CNRI-Python.json",
-      "referenceNumber": 101,
+      "referenceNumber": 316,
       "name": "CNRI Python License",
       "licenseId": "CNRI-Python",
       "seeAlso": [
@@ -2334,7 +2448,7 @@
       "reference": "https://spdx.org/licenses/CNRI-Python-GPL-Compatible.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
-      "referenceNumber": 533,
+      "referenceNumber": 672,
       "name": "CNRI Python Open Source GPL Compatible License Agreement",
       "licenseId": "CNRI-Python-GPL-Compatible",
       "seeAlso": [
@@ -2346,7 +2460,7 @@
       "reference": "https://spdx.org/licenses/COIL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/COIL-1.0.json",
-      "referenceNumber": 577,
+      "referenceNumber": 171,
       "name": "Copyfree Open Innovation License",
       "licenseId": "COIL-1.0",
       "seeAlso": [
@@ -2358,7 +2472,7 @@
       "reference": "https://spdx.org/licenses/Community-Spec-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Community-Spec-1.0.json",
-      "referenceNumber": 596,
+      "referenceNumber": 528,
       "name": "Community Specification License 1.0",
       "licenseId": "Community-Spec-1.0",
       "seeAlso": [
@@ -2370,7 +2484,7 @@
       "reference": "https://spdx.org/licenses/Condor-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Condor-1.1.json",
-      "referenceNumber": 548,
+      "referenceNumber": 481,
       "name": "Condor Public License v1.1",
       "licenseId": "Condor-1.1",
       "seeAlso": [
@@ -2384,7 +2498,7 @@
       "reference": "https://spdx.org/licenses/copyleft-next-0.3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/copyleft-next-0.3.0.json",
-      "referenceNumber": 361,
+      "referenceNumber": 3,
       "name": "copyleft-next 0.3.0",
       "licenseId": "copyleft-next-0.3.0",
       "seeAlso": [
@@ -2396,7 +2510,7 @@
       "reference": "https://spdx.org/licenses/copyleft-next-0.3.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/copyleft-next-0.3.1.json",
-      "referenceNumber": 71,
+      "referenceNumber": 369,
       "name": "copyleft-next 0.3.1",
       "licenseId": "copyleft-next-0.3.1",
       "seeAlso": [
@@ -2408,7 +2522,7 @@
       "reference": "https://spdx.org/licenses/Cornell-Lossless-JPEG.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Cornell-Lossless-JPEG.json",
-      "referenceNumber": 202,
+      "referenceNumber": 494,
       "name": "Cornell Lossless JPEG License",
       "licenseId": "Cornell-Lossless-JPEG",
       "seeAlso": [
@@ -2422,7 +2536,7 @@
       "reference": "https://spdx.org/licenses/CPAL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CPAL-1.0.json",
-      "referenceNumber": 543,
+      "referenceNumber": 164,
       "name": "Common Public Attribution License 1.0",
       "licenseId": "CPAL-1.0",
       "seeAlso": [
@@ -2435,7 +2549,7 @@
       "reference": "https://spdx.org/licenses/CPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CPL-1.0.json",
-      "referenceNumber": 619,
+      "referenceNumber": 18,
       "name": "Common Public License 1.0",
       "licenseId": "CPL-1.0",
       "seeAlso": [
@@ -2448,7 +2562,7 @@
       "reference": "https://spdx.org/licenses/CPOL-1.02.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CPOL-1.02.json",
-      "referenceNumber": 54,
+      "referenceNumber": 688,
       "name": "Code Project Open License 1.02",
       "licenseId": "CPOL-1.02",
       "seeAlso": [
@@ -2461,7 +2575,7 @@
       "reference": "https://spdx.org/licenses/Cronyx.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Cronyx.json",
-      "referenceNumber": 205,
+      "referenceNumber": 195,
       "name": "Cronyx License",
       "licenseId": "Cronyx",
       "seeAlso": [
@@ -2476,7 +2590,7 @@
       "reference": "https://spdx.org/licenses/Crossword.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Crossword.json",
-      "referenceNumber": 431,
+      "referenceNumber": 349,
       "name": "Crossword License",
       "licenseId": "Crossword",
       "seeAlso": [
@@ -2485,10 +2599,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/CryptoSwift.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CryptoSwift.json",
+      "referenceNumber": 27,
+      "name": "CryptoSwift License",
+      "licenseId": "CryptoSwift",
+      "seeAlso": [
+        "https://github.com/krzyzanowskim/CryptoSwift/blob/main/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/CrystalStacker.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CrystalStacker.json",
-      "referenceNumber": 298,
+      "referenceNumber": 397,
       "name": "CrystalStacker License",
       "licenseId": "CrystalStacker",
       "seeAlso": [
@@ -2500,7 +2626,7 @@
       "reference": "https://spdx.org/licenses/CUA-OPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CUA-OPL-1.0.json",
-      "referenceNumber": 216,
+      "referenceNumber": 597,
       "name": "CUA Office Public License v1.0",
       "licenseId": "CUA-OPL-1.0",
       "seeAlso": [
@@ -2512,7 +2638,7 @@
       "reference": "https://spdx.org/licenses/Cube.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Cube.json",
-      "referenceNumber": 289,
+      "referenceNumber": 402,
       "name": "Cube License",
       "licenseId": "Cube",
       "seeAlso": [
@@ -2524,7 +2650,7 @@
       "reference": "https://spdx.org/licenses/curl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/curl.json",
-      "referenceNumber": 220,
+      "referenceNumber": 504,
       "name": "curl License",
       "licenseId": "curl",
       "seeAlso": [
@@ -2536,7 +2662,7 @@
       "reference": "https://spdx.org/licenses/cve-tou.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/cve-tou.json",
-      "referenceNumber": 479,
+      "referenceNumber": 301,
       "name": "Common Vulnerability Enumeration ToU License",
       "licenseId": "cve-tou",
       "seeAlso": [
@@ -2548,7 +2674,7 @@
       "reference": "https://spdx.org/licenses/D-FSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/D-FSL-1.0.json",
-      "referenceNumber": 177,
+      "referenceNumber": 456,
       "name": "Deutsche Freie Software Lizenz",
       "licenseId": "D-FSL-1.0",
       "seeAlso": [
@@ -2567,7 +2693,7 @@
       "reference": "https://spdx.org/licenses/DEC-3-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DEC-3-Clause.json",
-      "referenceNumber": 235,
+      "referenceNumber": 475,
       "name": "DEC 3-Clause License",
       "licenseId": "DEC-3-Clause",
       "seeAlso": [
@@ -2579,7 +2705,7 @@
       "reference": "https://spdx.org/licenses/diffmark.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/diffmark.json",
-      "referenceNumber": 348,
+      "referenceNumber": 539,
       "name": "diffmark license",
       "licenseId": "diffmark",
       "seeAlso": [
@@ -2591,7 +2717,7 @@
       "reference": "https://spdx.org/licenses/DL-DE-BY-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DL-DE-BY-2.0.json",
-      "referenceNumber": 416,
+      "referenceNumber": 153,
       "name": "Data licence Germany – attribution – version 2.0",
       "licenseId": "DL-DE-BY-2.0",
       "seeAlso": [
@@ -2603,7 +2729,7 @@
       "reference": "https://spdx.org/licenses/DL-DE-ZERO-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DL-DE-ZERO-2.0.json",
-      "referenceNumber": 126,
+      "referenceNumber": 355,
       "name": "Data licence Germany – zero – version 2.0",
       "licenseId": "DL-DE-ZERO-2.0",
       "seeAlso": [
@@ -2615,7 +2741,7 @@
       "reference": "https://spdx.org/licenses/DOC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DOC.json",
-      "referenceNumber": 325,
+      "referenceNumber": 182,
       "name": "DOC License",
       "licenseId": "DOC",
       "seeAlso": [
@@ -2625,10 +2751,58 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/DocBook-DTD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DocBook-DTD.json",
+      "referenceNumber": 620,
+      "name": "DocBook DTD License",
+      "licenseId": "DocBook-DTD",
+      "seeAlso": [
+        "http://www.docbook.org/xml/simple/1.1/docbook-simple-1.1.zip"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DocBook-Schema.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DocBook-Schema.json",
+      "referenceNumber": 89,
+      "name": "DocBook Schema License",
+      "licenseId": "DocBook-Schema",
+      "seeAlso": [
+        "https://github.com/docbook/xslt10-stylesheets/blob/efd62655c11cc8773708df7a843613fa1e932bf8/xsl/assembly/schema/docbook51b7.rnc"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DocBook-Stylesheet.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DocBook-Stylesheet.json",
+      "referenceNumber": 278,
+      "name": "DocBook Stylesheet License",
+      "licenseId": "DocBook-Stylesheet",
+      "seeAlso": [
+        "http://www.docbook.org/xml/5.0/docbook-5.0.zip"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DocBook-XML.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DocBook-XML.json",
+      "referenceNumber": 490,
+      "name": "DocBook XML License",
+      "licenseId": "DocBook-XML",
+      "seeAlso": [
+        "https://github.com/docbook/xslt10-stylesheets/blob/efd62655c11cc8773708df7a843613fa1e932bf8/xsl/COPYING#L27"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/Dotseqn.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Dotseqn.json",
-      "referenceNumber": 207,
+      "referenceNumber": 157,
       "name": "Dotseqn License",
       "licenseId": "Dotseqn",
       "seeAlso": [
@@ -2640,7 +2814,7 @@
       "reference": "https://spdx.org/licenses/DRL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DRL-1.0.json",
-      "referenceNumber": 176,
+      "referenceNumber": 634,
       "name": "Detection Rule License 1.0",
       "licenseId": "DRL-1.0",
       "seeAlso": [
@@ -2652,7 +2826,7 @@
       "reference": "https://spdx.org/licenses/DRL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DRL-1.1.json",
-      "referenceNumber": 569,
+      "referenceNumber": 322,
       "name": "Detection Rule License 1.1",
       "licenseId": "DRL-1.1",
       "seeAlso": [
@@ -2664,7 +2838,7 @@
       "reference": "https://spdx.org/licenses/DSDP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DSDP.json",
-      "referenceNumber": 118,
+      "referenceNumber": 248,
       "name": "DSDP License",
       "licenseId": "DSDP",
       "seeAlso": [
@@ -2676,7 +2850,7 @@
       "reference": "https://spdx.org/licenses/dtoa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/dtoa.json",
-      "referenceNumber": 2,
+      "referenceNumber": 589,
       "name": "David M. Gay dtoa License",
       "licenseId": "dtoa",
       "seeAlso": [
@@ -2689,7 +2863,7 @@
       "reference": "https://spdx.org/licenses/dvipdfm.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/dvipdfm.json",
-      "referenceNumber": 256,
+      "referenceNumber": 653,
       "name": "dvipdfm License",
       "licenseId": "dvipdfm",
       "seeAlso": [
@@ -2701,7 +2875,7 @@
       "reference": "https://spdx.org/licenses/ECL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ECL-1.0.json",
-      "referenceNumber": 229,
+      "referenceNumber": 523,
       "name": "Educational Community License v1.0",
       "licenseId": "ECL-1.0",
       "seeAlso": [
@@ -2713,7 +2887,7 @@
       "reference": "https://spdx.org/licenses/ECL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ECL-2.0.json",
-      "referenceNumber": 483,
+      "referenceNumber": 9,
       "name": "Educational Community License v2.0",
       "licenseId": "ECL-2.0",
       "seeAlso": [
@@ -2726,7 +2900,7 @@
       "reference": "https://spdx.org/licenses/eCos-2.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/eCos-2.0.json",
-      "referenceNumber": 190,
+      "referenceNumber": 324,
       "name": "eCos license version 2.0",
       "licenseId": "eCos-2.0",
       "seeAlso": [
@@ -2739,7 +2913,7 @@
       "reference": "https://spdx.org/licenses/EFL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EFL-1.0.json",
-      "referenceNumber": 327,
+      "referenceNumber": 34,
       "name": "Eiffel Forum License v1.0",
       "licenseId": "EFL-1.0",
       "seeAlso": [
@@ -2752,7 +2926,7 @@
       "reference": "https://spdx.org/licenses/EFL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EFL-2.0.json",
-      "referenceNumber": 470,
+      "referenceNumber": 512,
       "name": "Eiffel Forum License v2.0",
       "licenseId": "EFL-2.0",
       "seeAlso": [
@@ -2766,7 +2940,7 @@
       "reference": "https://spdx.org/licenses/eGenix.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/eGenix.json",
-      "referenceNumber": 546,
+      "referenceNumber": 503,
       "name": "eGenix.com Public License 1.1.0",
       "licenseId": "eGenix",
       "seeAlso": [
@@ -2779,7 +2953,7 @@
       "reference": "https://spdx.org/licenses/Elastic-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Elastic-2.0.json",
-      "referenceNumber": 635,
+      "referenceNumber": 651,
       "name": "Elastic License 2.0",
       "licenseId": "Elastic-2.0",
       "seeAlso": [
@@ -2792,7 +2966,7 @@
       "reference": "https://spdx.org/licenses/Entessa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Entessa.json",
-      "referenceNumber": 507,
+      "referenceNumber": 238,
       "name": "Entessa Public License v1.0",
       "licenseId": "Entessa",
       "seeAlso": [
@@ -2804,7 +2978,7 @@
       "reference": "https://spdx.org/licenses/EPICS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EPICS.json",
-      "referenceNumber": 174,
+      "referenceNumber": 362,
       "name": "EPICS Open License",
       "licenseId": "EPICS",
       "seeAlso": [
@@ -2816,7 +2990,7 @@
       "reference": "https://spdx.org/licenses/EPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EPL-1.0.json",
-      "referenceNumber": 326,
+      "referenceNumber": 432,
       "name": "Eclipse Public License 1.0",
       "licenseId": "EPL-1.0",
       "seeAlso": [
@@ -2830,12 +3004,14 @@
       "reference": "https://spdx.org/licenses/EPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EPL-2.0.json",
-      "referenceNumber": 90,
+      "referenceNumber": 58,
       "name": "Eclipse Public License 2.0",
       "licenseId": "EPL-2.0",
       "seeAlso": [
         "https://www.eclipse.org/legal/epl-2.0",
-        "https://www.opensource.org/licenses/EPL-2.0"
+        "https://www.opensource.org/licenses/EPL-2.0",
+        "https://www.eclipse.org/legal/epl-v20.html",
+        "https://projects.eclipse.org/license/epl-2.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -2844,7 +3020,7 @@
       "reference": "https://spdx.org/licenses/ErlPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ErlPL-1.1.json",
-      "referenceNumber": 175,
+      "referenceNumber": 360,
       "name": "Erlang Public License v1.1",
       "licenseId": "ErlPL-1.1",
       "seeAlso": [
@@ -2853,10 +3029,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/ESA-PL-weak-copyleft-2.4.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ESA-PL-weak-copyleft-2.4.json",
+      "referenceNumber": 571,
+      "name": "European Space Agency Public License – v2.4 – Weak Copyleft (Type 2)",
+      "licenseId": "ESA-PL-weak-copyleft-2.4",
+      "seeAlso": [
+        "https://essr.esa.int/license/european-space-agency-public-license-v2-4-weak-copyleft-type-2"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/etalab-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/etalab-2.0.json",
-      "referenceNumber": 590,
+      "referenceNumber": 454,
       "name": "Etalab Open License 2.0",
       "licenseId": "etalab-2.0",
       "seeAlso": [
@@ -2869,7 +3057,7 @@
       "reference": "https://spdx.org/licenses/EUDatagrid.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EUDatagrid.json",
-      "referenceNumber": 642,
+      "referenceNumber": 534,
       "name": "EU DataGrid Software License",
       "licenseId": "EUDatagrid",
       "seeAlso": [
@@ -2883,7 +3071,7 @@
       "reference": "https://spdx.org/licenses/EUPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EUPL-1.0.json",
-      "referenceNumber": 302,
+      "referenceNumber": 611,
       "name": "European Union Public License 1.0",
       "licenseId": "EUPL-1.0",
       "seeAlso": [
@@ -2896,7 +3084,7 @@
       "reference": "https://spdx.org/licenses/EUPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EUPL-1.1.json",
-      "referenceNumber": 482,
+      "referenceNumber": 669,
       "name": "European Union Public License 1.1",
       "licenseId": "EUPL-1.1",
       "seeAlso": [
@@ -2911,7 +3099,7 @@
       "reference": "https://spdx.org/licenses/EUPL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EUPL-1.2.json",
-      "referenceNumber": 489,
+      "referenceNumber": 294,
       "name": "European Union Public License 1.2",
       "licenseId": "EUPL-1.2",
       "seeAlso": [
@@ -2929,7 +3117,7 @@
       "reference": "https://spdx.org/licenses/Eurosym.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Eurosym.json",
-      "referenceNumber": 434,
+      "referenceNumber": 271,
       "name": "Eurosym License",
       "licenseId": "Eurosym",
       "seeAlso": [
@@ -2941,7 +3129,7 @@
       "reference": "https://spdx.org/licenses/Fair.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Fair.json",
-      "referenceNumber": 448,
+      "referenceNumber": 488,
       "name": "Fair License",
       "licenseId": "Fair",
       "seeAlso": [
@@ -2954,7 +3142,7 @@
       "reference": "https://spdx.org/licenses/FBM.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FBM.json",
-      "referenceNumber": 255,
+      "referenceNumber": 303,
       "name": "Fuzzy Bitmap License",
       "licenseId": "FBM",
       "seeAlso": [
@@ -2966,7 +3154,7 @@
       "reference": "https://spdx.org/licenses/FDK-AAC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FDK-AAC.json",
-      "referenceNumber": 80,
+      "referenceNumber": 495,
       "name": "Fraunhofer FDK AAC Codec Library",
       "licenseId": "FDK-AAC",
       "seeAlso": [
@@ -2979,7 +3167,7 @@
       "reference": "https://spdx.org/licenses/Ferguson-Twofish.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Ferguson-Twofish.json",
-      "referenceNumber": 409,
+      "referenceNumber": 313,
       "name": "Ferguson Twofish License",
       "licenseId": "Ferguson-Twofish",
       "seeAlso": [
@@ -2991,7 +3179,7 @@
       "reference": "https://spdx.org/licenses/Frameworx-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Frameworx-1.0.json",
-      "referenceNumber": 259,
+      "referenceNumber": 421,
       "name": "Frameworx Open License 1.0",
       "licenseId": "Frameworx-1.0",
       "seeAlso": [
@@ -3003,7 +3191,7 @@
       "reference": "https://spdx.org/licenses/FreeBSD-DOC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FreeBSD-DOC.json",
-      "referenceNumber": 516,
+      "referenceNumber": 596,
       "name": "FreeBSD Documentation License",
       "licenseId": "FreeBSD-DOC",
       "seeAlso": [
@@ -3015,7 +3203,7 @@
       "reference": "https://spdx.org/licenses/FreeImage.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FreeImage.json",
-      "referenceNumber": 131,
+      "referenceNumber": 330,
       "name": "FreeImage Public License v1.0",
       "licenseId": "FreeImage",
       "seeAlso": [
@@ -3027,7 +3215,7 @@
       "reference": "https://spdx.org/licenses/FSFAP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFAP.json",
-      "referenceNumber": 529,
+      "referenceNumber": 332,
       "name": "FSF All Permissive License",
       "licenseId": "FSFAP",
       "seeAlso": [
@@ -3040,7 +3228,7 @@
       "reference": "https://spdx.org/licenses/FSFAP-no-warranty-disclaimer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFAP-no-warranty-disclaimer.json",
-      "referenceNumber": 19,
+      "referenceNumber": 529,
       "name": "FSF All Permissive License (without Warranty)",
       "licenseId": "FSFAP-no-warranty-disclaimer",
       "seeAlso": [
@@ -3052,7 +3240,7 @@
       "reference": "https://spdx.org/licenses/FSFUL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFUL.json",
-      "referenceNumber": 386,
+      "referenceNumber": 648,
       "name": "FSF Unlimited License",
       "licenseId": "FSFUL",
       "seeAlso": [
@@ -3064,7 +3252,7 @@
       "reference": "https://spdx.org/licenses/FSFULLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFULLR.json",
-      "referenceNumber": 468,
+      "referenceNumber": 581,
       "name": "FSF Unlimited License (with License Retention)",
       "licenseId": "FSFULLR",
       "seeAlso": [
@@ -3073,10 +3261,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/FSFULLRSD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSFULLRSD.json",
+      "referenceNumber": 267,
+      "name": "FSF Unlimited License (with License Retention and Short Disclaimer)",
+      "licenseId": "FSFULLRSD",
+      "seeAlso": [
+        "https://git.savannah.gnu.org/cgit/gnulib.git/tree/modules/COPYING?id\u003d7b08932179d0d6b017f7df01a2ddf6e096b038e3"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/FSFULLRWD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFULLRWD.json",
-      "referenceNumber": 305,
+      "referenceNumber": 460,
       "name": "FSF Unlimited License (With License Retention and Warranty Disclaimer)",
       "licenseId": "FSFULLRWD",
       "seeAlso": [
@@ -3085,10 +3285,34 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/FSL-1.1-ALv2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSL-1.1-ALv2.json",
+      "referenceNumber": 677,
+      "name": "Functional Source License, Version 1.1, ALv2 Future License",
+      "licenseId": "FSL-1.1-ALv2",
+      "seeAlso": [
+        "https://fsl.software/FSL-1.1-ALv2.template.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSL-1.1-MIT.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSL-1.1-MIT.json",
+      "referenceNumber": 64,
+      "name": "Functional Source License, Version 1.1, MIT Future License",
+      "licenseId": "FSL-1.1-MIT",
+      "seeAlso": [
+        "https://fsl.software/FSL-1.1-MIT.template.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/FTL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FTL.json",
-      "referenceNumber": 518,
+      "referenceNumber": 386,
       "name": "Freetype Project License",
       "licenseId": "FTL",
       "seeAlso": [
@@ -3103,7 +3327,7 @@
       "reference": "https://spdx.org/licenses/Furuseth.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Furuseth.json",
-      "referenceNumber": 208,
+      "referenceNumber": 465,
       "name": "Furuseth License",
       "licenseId": "Furuseth",
       "seeAlso": [
@@ -3115,7 +3339,7 @@
       "reference": "https://spdx.org/licenses/fwlw.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/fwlw.json",
-      "referenceNumber": 147,
+      "referenceNumber": 323,
       "name": "fwlw License",
       "licenseId": "fwlw",
       "seeAlso": [
@@ -3124,10 +3348,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/Game-Programming-Gems.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Game-Programming-Gems.json",
+      "referenceNumber": 643,
+      "name": "Game Programming Gems License",
+      "licenseId": "Game-Programming-Gems",
+      "seeAlso": [
+        "https://github.com/OGRECave/ogre/blob/master/OgreMain/include/OgreSingleton.h#L28C3-L35C46"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/GCR-docs.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GCR-docs.json",
-      "referenceNumber": 280,
+      "referenceNumber": 601,
       "name": "Gnome GCR Documentation License",
       "licenseId": "GCR-docs",
       "seeAlso": [
@@ -3139,7 +3375,7 @@
       "reference": "https://spdx.org/licenses/GD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GD.json",
-      "referenceNumber": 67,
+      "referenceNumber": 16,
       "name": "GD License",
       "licenseId": "GD",
       "seeAlso": [
@@ -3148,10 +3384,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/generic-xts.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/generic-xts.json",
+      "referenceNumber": 14,
+      "name": "Generic XTS License",
+      "licenseId": "generic-xts",
+      "seeAlso": [
+        "https://github.com/mhogomchungu/zuluCrypt/blob/master/external_libraries/tcplay/generic_xts.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/GFDL-1.1.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1.json",
-      "referenceNumber": 57,
+      "referenceNumber": 169,
       "name": "GNU Free Documentation License v1.1",
       "licenseId": "GFDL-1.1",
       "seeAlso": [
@@ -3164,7 +3412,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-invariants-only.json",
-      "referenceNumber": 355,
+      "referenceNumber": 275,
       "name": "GNU Free Documentation License v1.1 only - invariants",
       "licenseId": "GFDL-1.1-invariants-only",
       "seeAlso": [
@@ -3176,7 +3424,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-invariants-or-later.json",
-      "referenceNumber": 211,
+      "referenceNumber": 76,
       "name": "GNU Free Documentation License v1.1 or later - invariants",
       "licenseId": "GFDL-1.1-invariants-or-later",
       "seeAlso": [
@@ -3188,7 +3436,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-no-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-no-invariants-only.json",
-      "referenceNumber": 111,
+      "referenceNumber": 99,
       "name": "GNU Free Documentation License v1.1 only - no invariants",
       "licenseId": "GFDL-1.1-no-invariants-only",
       "seeAlso": [
@@ -3200,7 +3448,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.json",
-      "referenceNumber": 440,
+      "referenceNumber": 261,
       "name": "GNU Free Documentation License v1.1 or later - no invariants",
       "licenseId": "GFDL-1.1-no-invariants-or-later",
       "seeAlso": [
@@ -3212,7 +3460,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-only.json",
-      "referenceNumber": 160,
+      "referenceNumber": 658,
       "name": "GNU Free Documentation License v1.1 only",
       "licenseId": "GFDL-1.1-only",
       "seeAlso": [
@@ -3225,7 +3473,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-or-later.json",
-      "referenceNumber": 16,
+      "referenceNumber": 389,
       "name": "GNU Free Documentation License v1.1 or later",
       "licenseId": "GFDL-1.1-or-later",
       "seeAlso": [
@@ -3238,7 +3486,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2.json",
-      "referenceNumber": 294,
+      "referenceNumber": 166,
       "name": "GNU Free Documentation License v1.2",
       "licenseId": "GFDL-1.2",
       "seeAlso": [
@@ -3251,7 +3499,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-invariants-only.json",
-      "referenceNumber": 93,
+      "referenceNumber": 145,
       "name": "GNU Free Documentation License v1.2 only - invariants",
       "licenseId": "GFDL-1.2-invariants-only",
       "seeAlso": [
@@ -3263,7 +3511,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-invariants-or-later.json",
-      "referenceNumber": 498,
+      "referenceNumber": 626,
       "name": "GNU Free Documentation License v1.2 or later - invariants",
       "licenseId": "GFDL-1.2-invariants-or-later",
       "seeAlso": [
@@ -3275,7 +3523,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-no-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-no-invariants-only.json",
-      "referenceNumber": 573,
+      "referenceNumber": 306,
       "name": "GNU Free Documentation License v1.2 only - no invariants",
       "licenseId": "GFDL-1.2-no-invariants-only",
       "seeAlso": [
@@ -3287,7 +3535,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.json",
-      "referenceNumber": 233,
+      "referenceNumber": 63,
       "name": "GNU Free Documentation License v1.2 or later - no invariants",
       "licenseId": "GFDL-1.2-no-invariants-or-later",
       "seeAlso": [
@@ -3299,7 +3547,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-only.json",
-      "referenceNumber": 58,
+      "referenceNumber": 243,
       "name": "GNU Free Documentation License v1.2 only",
       "licenseId": "GFDL-1.2-only",
       "seeAlso": [
@@ -3312,7 +3560,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-or-later.json",
-      "referenceNumber": 155,
+      "referenceNumber": 235,
       "name": "GNU Free Documentation License v1.2 or later",
       "licenseId": "GFDL-1.2-or-later",
       "seeAlso": [
@@ -3325,7 +3573,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3.json",
-      "referenceNumber": 486,
+      "referenceNumber": 372,
       "name": "GNU Free Documentation License v1.3",
       "licenseId": "GFDL-1.3",
       "seeAlso": [
@@ -3338,7 +3586,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-invariants-only.json",
-      "referenceNumber": 541,
+      "referenceNumber": 242,
       "name": "GNU Free Documentation License v1.3 only - invariants",
       "licenseId": "GFDL-1.3-invariants-only",
       "seeAlso": [
@@ -3350,7 +3598,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-invariants-or-later.json",
-      "referenceNumber": 621,
+      "referenceNumber": 429,
       "name": "GNU Free Documentation License v1.3 or later - invariants",
       "licenseId": "GFDL-1.3-invariants-or-later",
       "seeAlso": [
@@ -3362,7 +3610,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-no-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-no-invariants-only.json",
-      "referenceNumber": 161,
+      "referenceNumber": 701,
       "name": "GNU Free Documentation License v1.3 only - no invariants",
       "licenseId": "GFDL-1.3-no-invariants-only",
       "seeAlso": [
@@ -3374,7 +3622,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.json",
-      "referenceNumber": 182,
+      "referenceNumber": 30,
       "name": "GNU Free Documentation License v1.3 or later - no invariants",
       "licenseId": "GFDL-1.3-no-invariants-or-later",
       "seeAlso": [
@@ -3386,7 +3634,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-only.json",
-      "referenceNumber": 288,
+      "referenceNumber": 252,
       "name": "GNU Free Documentation License v1.3 only",
       "licenseId": "GFDL-1.3-only",
       "seeAlso": [
@@ -3399,7 +3647,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-or-later.json",
-      "referenceNumber": 369,
+      "referenceNumber": 445,
       "name": "GNU Free Documentation License v1.3 or later",
       "licenseId": "GFDL-1.3-or-later",
       "seeAlso": [
@@ -3412,7 +3660,7 @@
       "reference": "https://spdx.org/licenses/Giftware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Giftware.json",
-      "referenceNumber": 223,
+      "referenceNumber": 548,
       "name": "Giftware License",
       "licenseId": "Giftware",
       "seeAlso": [
@@ -3424,7 +3672,7 @@
       "reference": "https://spdx.org/licenses/GL2PS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GL2PS.json",
-      "referenceNumber": 493,
+      "referenceNumber": 665,
       "name": "GL2PS License",
       "licenseId": "GL2PS",
       "seeAlso": [
@@ -3436,7 +3684,7 @@
       "reference": "https://spdx.org/licenses/Glide.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Glide.json",
-      "referenceNumber": 121,
+      "referenceNumber": 557,
       "name": "3dfx Glide License",
       "licenseId": "Glide",
       "seeAlso": [
@@ -3448,7 +3696,7 @@
       "reference": "https://spdx.org/licenses/Glulxe.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Glulxe.json",
-      "referenceNumber": 404,
+      "referenceNumber": 673,
       "name": "Glulxe License",
       "licenseId": "Glulxe",
       "seeAlso": [
@@ -3460,7 +3708,7 @@
       "reference": "https://spdx.org/licenses/GLWTPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GLWTPL.json",
-      "referenceNumber": 240,
+      "referenceNumber": 318,
       "name": "Good Luck With That Public License",
       "licenseId": "GLWTPL",
       "seeAlso": [
@@ -3472,7 +3720,7 @@
       "reference": "https://spdx.org/licenses/gnuplot.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/gnuplot.json",
-      "referenceNumber": 156,
+      "referenceNumber": 65,
       "name": "gnuplot License",
       "licenseId": "gnuplot",
       "seeAlso": [
@@ -3485,7 +3733,7 @@
       "reference": "https://spdx.org/licenses/GPL-1.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-1.0.json",
-      "referenceNumber": 368,
+      "referenceNumber": 33,
       "name": "GNU General Public License v1.0 only",
       "licenseId": "GPL-1.0",
       "seeAlso": [
@@ -3497,7 +3745,7 @@
       "reference": "https://spdx.org/licenses/GPL-1.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-1.0+.json",
-      "referenceNumber": 51,
+      "referenceNumber": 553,
       "name": "GNU General Public License v1.0 or later",
       "licenseId": "GPL-1.0+",
       "seeAlso": [
@@ -3509,7 +3757,7 @@
       "reference": "https://spdx.org/licenses/GPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-1.0-only.json",
-      "referenceNumber": 244,
+      "referenceNumber": 552,
       "name": "GNU General Public License v1.0 only",
       "licenseId": "GPL-1.0-only",
       "seeAlso": [
@@ -3521,7 +3769,7 @@
       "reference": "https://spdx.org/licenses/GPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-1.0-or-later.json",
-      "referenceNumber": 187,
+      "referenceNumber": 28,
       "name": "GNU General Public License v1.0 or later",
       "licenseId": "GPL-1.0-or-later",
       "seeAlso": [
@@ -3533,7 +3781,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0.json",
-      "referenceNumber": 462,
+      "referenceNumber": 317,
       "name": "GNU General Public License v2.0 only",
       "licenseId": "GPL-2.0",
       "seeAlso": [
@@ -3547,7 +3795,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0+.json",
-      "referenceNumber": 352,
+      "referenceNumber": 87,
       "name": "GNU General Public License v2.0 or later",
       "licenseId": "GPL-2.0+",
       "seeAlso": [
@@ -3561,13 +3809,14 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-only.json",
-      "referenceNumber": 618,
+      "referenceNumber": 129,
       "name": "GNU General Public License v2.0 only",
       "licenseId": "GPL-2.0-only",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
         "https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt",
-        "https://opensource.org/licenses/GPL-2.0"
+        "https://opensource.org/licenses/GPL-2.0",
+        "https://github.com/openjdk/jdk/blob/6162e2c5213c5dd7c1127fd9616b543efa898962/LICENSE"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -3576,12 +3825,13 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-or-later.json",
-      "referenceNumber": 11,
+      "referenceNumber": 305,
       "name": "GNU General Public License v2.0 or later",
       "licenseId": "GPL-2.0-or-later",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "https://opensource.org/licenses/GPL-2.0"
+        "https://opensource.org/licenses/GPL-2.0",
+        "https://github.com/openjdk/jdk/blob/6162e2c5213c5dd7c1127fd9616b543efa898962/LICENSE"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -3590,7 +3840,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
-      "referenceNumber": 632,
+      "referenceNumber": 668,
       "name": "GNU General Public License v2.0 w/Autoconf exception",
       "licenseId": "GPL-2.0-with-autoconf-exception",
       "seeAlso": [
@@ -3602,7 +3852,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
-      "referenceNumber": 296,
+      "referenceNumber": 582,
       "name": "GNU General Public License v2.0 w/Bison exception",
       "licenseId": "GPL-2.0-with-bison-exception",
       "seeAlso": [
@@ -3614,7 +3864,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
-      "referenceNumber": 613,
+      "referenceNumber": 650,
       "name": "GNU General Public License v2.0 w/Classpath exception",
       "licenseId": "GPL-2.0-with-classpath-exception",
       "seeAlso": [
@@ -3626,7 +3876,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-font-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-font-exception.json",
-      "referenceNumber": 258,
+      "referenceNumber": 502,
       "name": "GNU General Public License v2.0 w/Font exception",
       "licenseId": "GPL-2.0-with-font-exception",
       "seeAlso": [
@@ -3638,7 +3888,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-GCC-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
-      "referenceNumber": 8,
+      "referenceNumber": 524,
       "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
       "licenseId": "GPL-2.0-with-GCC-exception",
       "seeAlso": [
@@ -3650,7 +3900,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0.json",
-      "referenceNumber": 517,
+      "referenceNumber": 470,
       "name": "GNU General Public License v3.0 only",
       "licenseId": "GPL-3.0",
       "seeAlso": [
@@ -3664,7 +3914,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0+.json",
-      "referenceNumber": 108,
+      "referenceNumber": 462,
       "name": "GNU General Public License v3.0 or later",
       "licenseId": "GPL-3.0+",
       "seeAlso": [
@@ -3678,7 +3928,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-only.json",
-      "referenceNumber": 394,
+      "referenceNumber": 236,
       "name": "GNU General Public License v3.0 only",
       "licenseId": "GPL-3.0-only",
       "seeAlso": [
@@ -3692,7 +3942,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-or-later.json",
-      "referenceNumber": 197,
+      "referenceNumber": 177,
       "name": "GNU General Public License v3.0 or later",
       "licenseId": "GPL-3.0-or-later",
       "seeAlso": [
@@ -3706,7 +3956,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
-      "referenceNumber": 42,
+      "referenceNumber": 499,
       "name": "GNU General Public License v3.0 w/Autoconf exception",
       "licenseId": "GPL-3.0-with-autoconf-exception",
       "seeAlso": [
@@ -3718,7 +3968,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0-with-GCC-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-with-GCC-exception.json",
-      "referenceNumber": 249,
+      "referenceNumber": 291,
       "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
       "licenseId": "GPL-3.0-with-GCC-exception",
       "seeAlso": [
@@ -3730,7 +3980,7 @@
       "reference": "https://spdx.org/licenses/Graphics-Gems.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Graphics-Gems.json",
-      "referenceNumber": 441,
+      "referenceNumber": 122,
       "name": "Graphics Gems License",
       "licenseId": "Graphics-Gems",
       "seeAlso": [
@@ -3742,7 +3992,7 @@
       "reference": "https://spdx.org/licenses/gSOAP-1.3b.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/gSOAP-1.3b.json",
-      "referenceNumber": 649,
+      "referenceNumber": 210,
       "name": "gSOAP Public License v1.3b",
       "licenseId": "gSOAP-1.3b",
       "seeAlso": [
@@ -3754,7 +4004,7 @@
       "reference": "https://spdx.org/licenses/gtkbook.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/gtkbook.json",
-      "referenceNumber": 554,
+      "referenceNumber": 204,
       "name": "gtkbook License",
       "licenseId": "gtkbook",
       "seeAlso": [
@@ -3764,10 +4014,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/Gutmann.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Gutmann.json",
+      "referenceNumber": 623,
+      "name": "Gutmann License",
+      "licenseId": "Gutmann",
+      "seeAlso": [
+        "https://www.cs.auckland.ac.nz/~pgut001/dumpasn1.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/HaskellReport.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HaskellReport.json",
-      "referenceNumber": 237,
+      "referenceNumber": 71,
       "name": "Haskell Language Report License",
       "licenseId": "HaskellReport",
       "seeAlso": [
@@ -3776,10 +4038,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/HDF5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HDF5.json",
+      "referenceNumber": 287,
+      "name": "HDF5 License",
+      "licenseId": "HDF5",
+      "seeAlso": [
+        "https://github.com/HDFGroup/hdf5/?tab\u003dLicense-1-ov-file#readme"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/hdparm.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/hdparm.json",
-      "referenceNumber": 167,
+      "referenceNumber": 220,
       "name": "hdparm License",
       "licenseId": "hdparm",
       "seeAlso": [
@@ -3788,10 +4062,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/HIDAPI.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HIDAPI.json",
+      "referenceNumber": 329,
+      "name": "HIDAPI License",
+      "licenseId": "HIDAPI",
+      "seeAlso": [
+        "https://github.com/signal11/hidapi/blob/master/LICENSE-orig.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/Hippocratic-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Hippocratic-2.1.json",
-      "referenceNumber": 20,
+      "referenceNumber": 277,
       "name": "Hippocratic License 2.1",
       "licenseId": "Hippocratic-2.1",
       "seeAlso": [
@@ -3804,7 +4090,7 @@
       "reference": "https://spdx.org/licenses/HP-1986.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HP-1986.json",
-      "referenceNumber": 495,
+      "referenceNumber": 148,
       "name": "Hewlett-Packard 1986 License",
       "licenseId": "HP-1986",
       "seeAlso": [
@@ -3816,7 +4102,7 @@
       "reference": "https://spdx.org/licenses/HP-1989.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HP-1989.json",
-      "referenceNumber": 408,
+      "referenceNumber": 532,
       "name": "Hewlett-Packard 1989 License",
       "licenseId": "HP-1989",
       "seeAlso": [
@@ -3828,7 +4114,7 @@
       "reference": "https://spdx.org/licenses/HPND.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND.json",
-      "referenceNumber": 251,
+      "referenceNumber": 184,
       "name": "Historical Permission Notice and Disclaimer",
       "licenseId": "HPND",
       "seeAlso": [
@@ -3842,7 +4128,7 @@
       "reference": "https://spdx.org/licenses/HPND-DEC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-DEC.json",
-      "referenceNumber": 447,
+      "referenceNumber": 284,
       "name": "Historical Permission Notice and Disclaimer - DEC variant",
       "licenseId": "HPND-DEC",
       "seeAlso": [
@@ -3854,7 +4140,7 @@
       "reference": "https://spdx.org/licenses/HPND-doc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-doc.json",
-      "referenceNumber": 490,
+      "referenceNumber": 298,
       "name": "Historical Permission Notice and Disclaimer - documentation variant",
       "licenseId": "HPND-doc",
       "seeAlso": [
@@ -3867,7 +4153,7 @@
       "reference": "https://spdx.org/licenses/HPND-doc-sell.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-doc-sell.json",
-      "referenceNumber": 375,
+      "referenceNumber": 337,
       "name": "Historical Permission Notice and Disclaimer - documentation sell variant",
       "licenseId": "HPND-doc-sell",
       "seeAlso": [
@@ -3880,7 +4166,7 @@
       "reference": "https://spdx.org/licenses/HPND-export-US.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-export-US.json",
-      "referenceNumber": 246,
+      "referenceNumber": 670,
       "name": "HPND with US Government export control warning",
       "licenseId": "HPND-export-US",
       "seeAlso": [
@@ -3889,10 +4175,23 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/HPND-export-US-acknowledgement.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-export-US-acknowledgement.json",
+      "referenceNumber": 255,
+      "name": "HPND with US Government export control warning and acknowledgment",
+      "licenseId": "HPND-export-US-acknowledgement",
+      "seeAlso": [
+        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L831-L852",
+        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/HPND-export-US-modify.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-export-US-modify.json",
-      "referenceNumber": 130,
+      "referenceNumber": 216,
       "name": "HPND with US Government export control warning and modification rqmt",
       "licenseId": "HPND-export-US-modify",
       "seeAlso": [
@@ -3902,10 +4201,23 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/HPND-export2-US.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-export2-US.json",
+      "referenceNumber": 441,
+      "name": "HPND with US Government export control and 2 disclaimers",
+      "licenseId": "HPND-export2-US",
+      "seeAlso": [
+        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L111-L133",
+        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/HPND-Fenneberg-Livingston.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Fenneberg-Livingston.json",
-      "referenceNumber": 363,
+      "referenceNumber": 144,
       "name": "Historical Permission Notice and Disclaimer - Fenneberg-Livingston variant",
       "licenseId": "HPND-Fenneberg-Livingston",
       "seeAlso": [
@@ -3918,7 +4230,7 @@
       "reference": "https://spdx.org/licenses/HPND-INRIA-IMAG.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-INRIA-IMAG.json",
-      "referenceNumber": 267,
+      "referenceNumber": 315,
       "name": "Historical Permission Notice and Disclaimer    - INRIA-IMAG variant",
       "licenseId": "HPND-INRIA-IMAG",
       "seeAlso": [
@@ -3927,10 +4239,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/HPND-Intel.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-Intel.json",
+      "referenceNumber": 394,
+      "name": "Historical Permission Notice and Disclaimer - Intel variant",
+      "licenseId": "HPND-Intel",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dnewlib-cygwin.git;a\u003dblob;f\u003dnewlib/libc/machine/i960/memcpy.S;hb\u003dHEAD"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/HPND-Kevlin-Henney.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Kevlin-Henney.json",
-      "referenceNumber": 334,
+      "referenceNumber": 333,
       "name": "Historical Permission Notice and Disclaimer - Kevlin Henney variant",
       "licenseId": "HPND-Kevlin-Henney",
       "seeAlso": [
@@ -3942,7 +4266,7 @@
       "reference": "https://spdx.org/licenses/HPND-Markus-Kuhn.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Markus-Kuhn.json",
-      "referenceNumber": 602,
+      "referenceNumber": 351,
       "name": "Historical Permission Notice and Disclaimer - Markus Kuhn variant",
       "licenseId": "HPND-Markus-Kuhn",
       "seeAlso": [
@@ -3952,10 +4276,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/HPND-merchantability-variant.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-merchantability-variant.json",
+      "referenceNumber": 564,
+      "name": "Historical Permission Notice and Disclaimer - merchantability variant",
+      "licenseId": "HPND-merchantability-variant",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dnewlib-cygwin.git;a\u003dblob;f\u003dnewlib/libc/misc/fini.c;hb\u003dHEAD"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/HPND-MIT-disclaimer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-MIT-disclaimer.json",
-      "referenceNumber": 84,
+      "referenceNumber": 138,
       "name": "Historical Permission Notice and Disclaimer with MIT disclaimer",
       "licenseId": "HPND-MIT-disclaimer",
       "seeAlso": [
@@ -3964,10 +4300,20 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/HPND-Netrek.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-Netrek.json",
+      "referenceNumber": 365,
+      "name": "Historical Permission Notice and Disclaimer - Netrek variant",
+      "licenseId": "HPND-Netrek",
+      "seeAlso": [],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/HPND-Pbmplus.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Pbmplus.json",
-      "referenceNumber": 52,
+      "referenceNumber": 342,
       "name": "Historical Permission Notice and Disclaimer - Pbmplus variant",
       "licenseId": "HPND-Pbmplus",
       "seeAlso": [
@@ -3979,7 +4325,7 @@
       "reference": "https://spdx.org/licenses/HPND-sell-MIT-disclaimer-xserver.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-MIT-disclaimer-xserver.json",
-      "referenceNumber": 503,
+      "referenceNumber": 344,
       "name": "Historical Permission Notice and Disclaimer - sell xserver variant with MIT disclaimer",
       "licenseId": "HPND-sell-MIT-disclaimer-xserver",
       "seeAlso": [
@@ -3991,7 +4337,7 @@
       "reference": "https://spdx.org/licenses/HPND-sell-regexpr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-regexpr.json",
-      "referenceNumber": 64,
+      "referenceNumber": 225,
       "name": "Historical Permission Notice and Disclaimer - sell regexpr variant",
       "licenseId": "HPND-sell-regexpr",
       "seeAlso": [
@@ -4003,11 +4349,12 @@
       "reference": "https://spdx.org/licenses/HPND-sell-variant.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant.json",
-      "referenceNumber": 85,
+      "referenceNumber": 535,
       "name": "Historical Permission Notice and Disclaimer - sell variant",
       "licenseId": "HPND-sell-variant",
       "seeAlso": [
-        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h\u003dv4.19"
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h\u003dv4.19",
+        "https://github.com/kfish/xsel/blob/master/COPYING"
       ],
       "isOsiApproved": false
     },
@@ -4015,7 +4362,7 @@
       "reference": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer.json",
-      "referenceNumber": 377,
+      "referenceNumber": 438,
       "name": "HPND sell variant with MIT disclaimer",
       "licenseId": "HPND-sell-variant-MIT-disclaimer",
       "seeAlso": [
@@ -4027,7 +4374,7 @@
       "reference": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer-rev.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer-rev.json",
-      "referenceNumber": 634,
+      "referenceNumber": 478,
       "name": "HPND sell variant with MIT disclaimer - reverse",
       "licenseId": "HPND-sell-variant-MIT-disclaimer-rev",
       "seeAlso": [
@@ -4039,7 +4386,7 @@
       "reference": "https://spdx.org/licenses/HPND-UC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-UC.json",
-      "referenceNumber": 243,
+      "referenceNumber": 191,
       "name": "Historical Permission Notice and Disclaimer - University of California variant",
       "licenseId": "HPND-UC",
       "seeAlso": [
@@ -4051,7 +4398,7 @@
       "reference": "https://spdx.org/licenses/HPND-UC-export-US.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-UC-export-US.json",
-      "referenceNumber": 275,
+      "referenceNumber": 134,
       "name": "Historical Permission Notice and Disclaimer - University of California, US export warning",
       "licenseId": "HPND-UC-export-US",
       "seeAlso": [
@@ -4063,7 +4410,7 @@
       "reference": "https://spdx.org/licenses/HTMLTIDY.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HTMLTIDY.json",
-      "referenceNumber": 21,
+      "referenceNumber": 509,
       "name": "HTML Tidy License",
       "licenseId": "HTMLTIDY",
       "seeAlso": [
@@ -4075,7 +4422,7 @@
       "reference": "https://spdx.org/licenses/IBM-pibs.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IBM-pibs.json",
-      "referenceNumber": 572,
+      "referenceNumber": 510,
       "name": "IBM PowerPC Initialization and Boot Software",
       "licenseId": "IBM-pibs",
       "seeAlso": [
@@ -4087,7 +4434,7 @@
       "reference": "https://spdx.org/licenses/ICU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ICU.json",
-      "referenceNumber": 198,
+      "referenceNumber": 290,
       "name": "ICU License",
       "licenseId": "ICU",
       "seeAlso": [
@@ -4113,7 +4460,7 @@
       "reference": "https://spdx.org/licenses/IJG.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IJG.json",
-      "referenceNumber": 342,
+      "referenceNumber": 664,
       "name": "Independent JPEG Group License",
       "licenseId": "IJG",
       "seeAlso": [
@@ -4126,7 +4473,7 @@
       "reference": "https://spdx.org/licenses/IJG-short.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IJG-short.json",
-      "referenceNumber": 576,
+      "referenceNumber": 239,
       "name": "Independent JPEG Group License - short",
       "licenseId": "IJG-short",
       "seeAlso": [
@@ -4138,7 +4485,7 @@
       "reference": "https://spdx.org/licenses/ImageMagick.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ImageMagick.json",
-      "referenceNumber": 465,
+      "referenceNumber": 568,
       "name": "ImageMagick License",
       "licenseId": "ImageMagick",
       "seeAlso": [
@@ -4150,7 +4497,7 @@
       "reference": "https://spdx.org/licenses/iMatix.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/iMatix.json",
-      "referenceNumber": 34,
+      "referenceNumber": 584,
       "name": "iMatix Standard Function Library Agreement",
       "licenseId": "iMatix",
       "seeAlso": [
@@ -4163,7 +4510,7 @@
       "reference": "https://spdx.org/licenses/Imlib2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Imlib2.json",
-      "referenceNumber": 466,
+      "referenceNumber": 35,
       "name": "Imlib2 License",
       "licenseId": "Imlib2",
       "seeAlso": [
@@ -4177,7 +4524,7 @@
       "reference": "https://spdx.org/licenses/Info-ZIP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Info-ZIP.json",
-      "referenceNumber": 633,
+      "referenceNumber": 604,
       "name": "Info-ZIP License",
       "licenseId": "Info-ZIP",
       "seeAlso": [
@@ -4189,7 +4536,7 @@
       "reference": "https://spdx.org/licenses/Inner-Net-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Inner-Net-2.0.json",
-      "referenceNumber": 241,
+      "referenceNumber": 384,
       "name": "Inner Net License v2.0",
       "licenseId": "Inner-Net-2.0",
       "seeAlso": [
@@ -4199,10 +4546,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/InnoSetup.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/InnoSetup.json",
+      "referenceNumber": 90,
+      "name": "Inno Setup License",
+      "licenseId": "InnoSetup",
+      "seeAlso": [
+        "https://github.com/jrsoftware/issrc/blob/HEAD/license.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/Intel.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Intel.json",
-      "referenceNumber": 476,
+      "referenceNumber": 202,
       "name": "Intel Open Source License",
       "licenseId": "Intel",
       "seeAlso": [
@@ -4215,7 +4574,7 @@
       "reference": "https://spdx.org/licenses/Intel-ACPI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Intel-ACPI.json",
-      "referenceNumber": 526,
+      "referenceNumber": 639,
       "name": "Intel ACPI Software License Agreement",
       "licenseId": "Intel-ACPI",
       "seeAlso": [
@@ -4227,7 +4586,7 @@
       "reference": "https://spdx.org/licenses/Interbase-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Interbase-1.0.json",
-      "referenceNumber": 450,
+      "referenceNumber": 411,
       "name": "Interbase Public License v1.0",
       "licenseId": "Interbase-1.0",
       "seeAlso": [
@@ -4239,7 +4598,7 @@
       "reference": "https://spdx.org/licenses/IPA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IPA.json",
-      "referenceNumber": 530,
+      "referenceNumber": 295,
       "name": "IPA Font License",
       "licenseId": "IPA",
       "seeAlso": [
@@ -4252,7 +4611,7 @@
       "reference": "https://spdx.org/licenses/IPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IPL-1.0.json",
-      "referenceNumber": 505,
+      "referenceNumber": 260,
       "name": "IBM Public License v1.0",
       "licenseId": "IPL-1.0",
       "seeAlso": [
@@ -4265,7 +4624,7 @@
       "reference": "https://spdx.org/licenses/ISC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ISC.json",
-      "referenceNumber": 53,
+      "referenceNumber": 4,
       "name": "ISC License",
       "licenseId": "ISC",
       "seeAlso": [
@@ -4280,12 +4639,13 @@
       "reference": "https://spdx.org/licenses/ISC-Veillard.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ISC-Veillard.json",
-      "referenceNumber": 449,
+      "referenceNumber": 300,
       "name": "ISC Veillard variant",
       "licenseId": "ISC-Veillard",
       "seeAlso": [
         "https://raw.githubusercontent.com/GNOME/libxml2/4c2e7c651f6c2f0d1a74f350cbda95f7df3e7017/hash.c",
-        "https://github.com/GNOME/libxml2/blob/master/dict.c"
+        "https://github.com/GNOME/libxml2/blob/master/dict.c",
+        "https://sourceforge.net/p/ctrio/git/ci/master/tree/README"
       ],
       "isOsiApproved": false
     },
@@ -4293,7 +4653,7 @@
       "reference": "https://spdx.org/licenses/Jam.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Jam.json",
-      "referenceNumber": 36,
+      "referenceNumber": 354,
       "name": "Jam License",
       "licenseId": "Jam",
       "seeAlso": [
@@ -4306,7 +4666,7 @@
       "reference": "https://spdx.org/licenses/JasPer-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/JasPer-2.0.json",
-      "referenceNumber": 446,
+      "referenceNumber": 142,
       "name": "JasPer License",
       "licenseId": "JasPer-2.0",
       "seeAlso": [
@@ -4315,10 +4675,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/jove.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/jove.json",
+      "referenceNumber": 434,
+      "name": "Jove License",
+      "licenseId": "jove",
+      "seeAlso": [
+        "https://github.com/jonmacs/jove/blob/4_17/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/JPL-image.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/JPL-image.json",
-      "referenceNumber": 217,
+      "referenceNumber": 364,
       "name": "JPL Image Use Policy",
       "licenseId": "JPL-image",
       "seeAlso": [
@@ -4330,7 +4702,7 @@
       "reference": "https://spdx.org/licenses/JPNIC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/JPNIC.json",
-      "referenceNumber": 456,
+      "referenceNumber": 531,
       "name": "Japan Network Information Center License",
       "licenseId": "JPNIC",
       "seeAlso": [
@@ -4342,7 +4714,7 @@
       "reference": "https://spdx.org/licenses/JSON.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/JSON.json",
-      "referenceNumber": 139,
+      "referenceNumber": 612,
       "name": "JSON License",
       "licenseId": "JSON",
       "seeAlso": [
@@ -4355,7 +4727,7 @@
       "reference": "https://spdx.org/licenses/Kastrup.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Kastrup.json",
-      "referenceNumber": 631,
+      "referenceNumber": 223,
       "name": "Kastrup License",
       "licenseId": "Kastrup",
       "seeAlso": [
@@ -4367,7 +4739,7 @@
       "reference": "https://spdx.org/licenses/Kazlib.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Kazlib.json",
-      "referenceNumber": 374,
+      "referenceNumber": 536,
       "name": "Kazlib License",
       "licenseId": "Kazlib",
       "seeAlso": [
@@ -4379,7 +4751,7 @@
       "reference": "https://spdx.org/licenses/Knuth-CTAN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Knuth-CTAN.json",
-      "referenceNumber": 496,
+      "referenceNumber": 530,
       "name": "Knuth CTAN License",
       "licenseId": "Knuth-CTAN",
       "seeAlso": [
@@ -4391,7 +4763,7 @@
       "reference": "https://spdx.org/licenses/LAL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LAL-1.2.json",
-      "referenceNumber": 312,
+      "referenceNumber": 607,
       "name": "Licence Art Libre 1.2",
       "licenseId": "LAL-1.2",
       "seeAlso": [
@@ -4403,7 +4775,7 @@
       "reference": "https://spdx.org/licenses/LAL-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LAL-1.3.json",
-      "referenceNumber": 605,
+      "referenceNumber": 234,
       "name": "Licence Art Libre 1.3",
       "licenseId": "LAL-1.3",
       "seeAlso": [
@@ -4415,7 +4787,7 @@
       "reference": "https://spdx.org/licenses/Latex2e.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Latex2e.json",
-      "referenceNumber": 142,
+      "referenceNumber": 186,
       "name": "Latex2e License",
       "licenseId": "Latex2e",
       "seeAlso": [
@@ -4427,7 +4799,7 @@
       "reference": "https://spdx.org/licenses/Latex2e-translated-notice.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Latex2e-translated-notice.json",
-      "referenceNumber": 607,
+      "referenceNumber": 110,
       "name": "Latex2e with translated notice permission",
       "licenseId": "Latex2e-translated-notice",
       "seeAlso": [
@@ -4439,7 +4811,7 @@
       "reference": "https://spdx.org/licenses/Leptonica.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Leptonica.json",
-      "referenceNumber": 27,
+      "referenceNumber": 60,
       "name": "Leptonica License",
       "licenseId": "Leptonica",
       "seeAlso": [
@@ -4451,7 +4823,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.0.json",
-      "referenceNumber": 549,
+      "referenceNumber": 203,
       "name": "GNU Library General Public License v2 only",
       "licenseId": "LGPL-2.0",
       "seeAlso": [
@@ -4463,7 +4835,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.0+.json",
-      "referenceNumber": 287,
+      "referenceNumber": 102,
       "name": "GNU Library General Public License v2 or later",
       "licenseId": "LGPL-2.0+",
       "seeAlso": [
@@ -4475,7 +4847,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.0-only.json",
-      "referenceNumber": 396,
+      "referenceNumber": 382,
       "name": "GNU Library General Public License v2 only",
       "licenseId": "LGPL-2.0-only",
       "seeAlso": [
@@ -4487,7 +4859,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.0-or-later.json",
-      "referenceNumber": 414,
+      "referenceNumber": 214,
       "name": "GNU Library General Public License v2 or later",
       "licenseId": "LGPL-2.0-or-later",
       "seeAlso": [
@@ -4499,7 +4871,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.1.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.1.json",
-      "referenceNumber": 169,
+      "referenceNumber": 450,
       "name": "GNU Lesser General Public License v2.1 only",
       "licenseId": "LGPL-2.1",
       "seeAlso": [
@@ -4513,7 +4885,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.1+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.1+.json",
-      "referenceNumber": 551,
+      "referenceNumber": 32,
       "name": "GNU Lesser General Public License v2.1 or later",
       "licenseId": "LGPL-2.1+",
       "seeAlso": [
@@ -4527,7 +4899,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.1-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.1-only.json",
-      "referenceNumber": 114,
+      "referenceNumber": 511,
       "name": "GNU Lesser General Public License v2.1 only",
       "licenseId": "LGPL-2.1-only",
       "seeAlso": [
@@ -4541,7 +4913,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.1-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.1-or-later.json",
-      "referenceNumber": 329,
+      "referenceNumber": 686,
       "name": "GNU Lesser General Public License v2.1 or later",
       "licenseId": "LGPL-2.1-or-later",
       "seeAlso": [
@@ -4555,7 +4927,7 @@
       "reference": "https://spdx.org/licenses/LGPL-3.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-3.0.json",
-      "referenceNumber": 647,
+      "referenceNumber": 127,
       "name": "GNU Lesser General Public License v3.0 only",
       "licenseId": "LGPL-3.0",
       "seeAlso": [
@@ -4570,7 +4942,7 @@
       "reference": "https://spdx.org/licenses/LGPL-3.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-3.0+.json",
-      "referenceNumber": 458,
+      "referenceNumber": 198,
       "name": "GNU Lesser General Public License v3.0 or later",
       "licenseId": "LGPL-3.0+",
       "seeAlso": [
@@ -4585,7 +4957,7 @@
       "reference": "https://spdx.org/licenses/LGPL-3.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-only.json",
-      "referenceNumber": 200,
+      "referenceNumber": 282,
       "name": "GNU Lesser General Public License v3.0 only",
       "licenseId": "LGPL-3.0-only",
       "seeAlso": [
@@ -4600,7 +4972,7 @@
       "reference": "https://spdx.org/licenses/LGPL-3.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-or-later.json",
-      "referenceNumber": 376,
+      "referenceNumber": 97,
       "name": "GNU Lesser General Public License v3.0 or later",
       "licenseId": "LGPL-3.0-or-later",
       "seeAlso": [
@@ -4615,7 +4987,7 @@
       "reference": "https://spdx.org/licenses/LGPLLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPLLR.json",
-      "referenceNumber": 7,
+      "referenceNumber": 408,
       "name": "Lesser General Public License For Linguistic Resources",
       "licenseId": "LGPLLR",
       "seeAlso": [
@@ -4627,9 +4999,21 @@
       "reference": "https://spdx.org/licenses/Libpng.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Libpng.json",
-      "referenceNumber": 310,
+      "referenceNumber": 75,
       "name": "libpng License",
       "licenseId": "Libpng",
+      "seeAlso": [
+        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/libpng-1.6.35.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/libpng-1.6.35.json",
+      "referenceNumber": 485,
+      "name": "PNG Reference Library License v1 (for libpng 0.5 through 1.6.35)",
+      "licenseId": "libpng-1.6.35",
       "seeAlso": [
         "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
       ],
@@ -4639,7 +5023,7 @@
       "reference": "https://spdx.org/licenses/libpng-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/libpng-2.0.json",
-      "referenceNumber": 638,
+      "referenceNumber": 178,
       "name": "PNG Reference Library version 2",
       "licenseId": "libpng-2.0",
       "seeAlso": [
@@ -4651,7 +5035,7 @@
       "reference": "https://spdx.org/licenses/libselinux-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/libselinux-1.0.json",
-      "referenceNumber": 595,
+      "referenceNumber": 498,
       "name": "libselinux public domain notice",
       "licenseId": "libselinux-1.0",
       "seeAlso": [
@@ -4663,7 +5047,7 @@
       "reference": "https://spdx.org/licenses/libtiff.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/libtiff.json",
-      "referenceNumber": 353,
+      "referenceNumber": 514,
       "name": "libtiff License",
       "licenseId": "libtiff",
       "seeAlso": [
@@ -4675,7 +5059,7 @@
       "reference": "https://spdx.org/licenses/libutil-David-Nugent.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/libutil-David-Nugent.json",
-      "referenceNumber": 629,
+      "referenceNumber": 352,
       "name": "libutil David Nugent License",
       "licenseId": "libutil-David-Nugent",
       "seeAlso": [
@@ -4688,7 +5072,7 @@
       "reference": "https://spdx.org/licenses/LiLiQ-P-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LiLiQ-P-1.1.json",
-      "referenceNumber": 461,
+      "referenceNumber": 423,
       "name": "Licence Libre du Québec – Permissive version 1.1",
       "licenseId": "LiLiQ-P-1.1",
       "seeAlso": [
@@ -4701,7 +5085,7 @@
       "reference": "https://spdx.org/licenses/LiLiQ-R-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LiLiQ-R-1.1.json",
-      "referenceNumber": 488,
+      "referenceNumber": 245,
       "name": "Licence Libre du Québec – Réciprocité version 1.1",
       "licenseId": "LiLiQ-R-1.1",
       "seeAlso": [
@@ -4714,7 +5098,7 @@
       "reference": "https://spdx.org/licenses/LiLiQ-Rplus-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
-      "referenceNumber": 455,
+      "referenceNumber": 8,
       "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
       "licenseId": "LiLiQ-Rplus-1.1",
       "seeAlso": [
@@ -4727,7 +5111,7 @@
       "reference": "https://spdx.org/licenses/Linux-man-pages-1-para.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-1-para.json",
-      "referenceNumber": 384,
+      "referenceNumber": 143,
       "name": "Linux man-pages - 1 paragraph",
       "licenseId": "Linux-man-pages-1-para",
       "seeAlso": [
@@ -4739,7 +5123,7 @@
       "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft.json",
-      "referenceNumber": 31,
+      "referenceNumber": 500,
       "name": "Linux man-pages Copyleft",
       "licenseId": "Linux-man-pages-copyleft",
       "seeAlso": [
@@ -4751,7 +5135,7 @@
       "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft-2-para.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft-2-para.json",
-      "referenceNumber": 6,
+      "referenceNumber": 542,
       "name": "Linux man-pages Copyleft - 2 paragraphs",
       "licenseId": "Linux-man-pages-copyleft-2-para",
       "seeAlso": [
@@ -4764,7 +5148,7 @@
       "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft-var.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft-var.json",
-      "referenceNumber": 172,
+      "referenceNumber": 588,
       "name": "Linux man-pages Copyleft Variant",
       "licenseId": "Linux-man-pages-copyleft-var",
       "seeAlso": [
@@ -4776,7 +5160,7 @@
       "reference": "https://spdx.org/licenses/Linux-OpenIB.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-OpenIB.json",
-      "referenceNumber": 203,
+      "referenceNumber": 172,
       "name": "Linux Kernel Variant of OpenIB.org license",
       "licenseId": "Linux-OpenIB",
       "seeAlso": [
@@ -4788,7 +5172,7 @@
       "reference": "https://spdx.org/licenses/LOOP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LOOP.json",
-      "referenceNumber": 94,
+      "referenceNumber": 232,
       "name": "Common Lisp LOOP License",
       "licenseId": "LOOP",
       "seeAlso": [
@@ -4805,7 +5189,7 @@
       "reference": "https://spdx.org/licenses/LPD-document.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPD-document.json",
-      "referenceNumber": 604,
+      "referenceNumber": 702,
       "name": "LPD Documentation License",
       "licenseId": "LPD-document",
       "seeAlso": [
@@ -4818,7 +5202,7 @@
       "reference": "https://spdx.org/licenses/LPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPL-1.0.json",
-      "referenceNumber": 157,
+      "referenceNumber": 2,
       "name": "Lucent Public License Version 1.0",
       "licenseId": "LPL-1.0",
       "seeAlso": [
@@ -4830,7 +5214,7 @@
       "reference": "https://spdx.org/licenses/LPL-1.02.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPL-1.02.json",
-      "referenceNumber": 558,
+      "referenceNumber": 217,
       "name": "Lucent Public License v1.02",
       "licenseId": "LPL-1.02",
       "seeAlso": [
@@ -4844,7 +5228,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.0.json",
-      "referenceNumber": 385,
+      "referenceNumber": 630,
       "name": "LaTeX Project Public License v1.0",
       "licenseId": "LPPL-1.0",
       "seeAlso": [
@@ -4856,7 +5240,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.1.json",
-      "referenceNumber": 417,
+      "referenceNumber": 257,
       "name": "LaTeX Project Public License v1.1",
       "licenseId": "LPPL-1.1",
       "seeAlso": [
@@ -4868,7 +5252,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.2.json",
-      "referenceNumber": 0,
+      "referenceNumber": 469,
       "name": "LaTeX Project Public License v1.2",
       "licenseId": "LPPL-1.2",
       "seeAlso": [
@@ -4881,7 +5265,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.3a.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.3a.json",
-      "referenceNumber": 152,
+      "referenceNumber": 125,
       "name": "LaTeX Project Public License v1.3a",
       "licenseId": "LPPL-1.3a",
       "seeAlso": [
@@ -4894,7 +5278,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.3c.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.3c.json",
-      "referenceNumber": 206,
+      "referenceNumber": 448,
       "name": "LaTeX Project Public License v1.3c",
       "licenseId": "LPPL-1.3c",
       "seeAlso": [
@@ -4907,7 +5291,7 @@
       "reference": "https://spdx.org/licenses/lsof.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/lsof.json",
-      "referenceNumber": 356,
+      "referenceNumber": 496,
       "name": "lsof License",
       "licenseId": "lsof",
       "seeAlso": [
@@ -4919,7 +5303,7 @@
       "reference": "https://spdx.org/licenses/Lucida-Bitmap-Fonts.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Lucida-Bitmap-Fonts.json",
-      "referenceNumber": 48,
+      "referenceNumber": 319,
       "name": "Lucida Bitmap Fonts License",
       "licenseId": "Lucida-Bitmap-Fonts",
       "seeAlso": [
@@ -4931,7 +5315,7 @@
       "reference": "https://spdx.org/licenses/LZMA-SDK-9.11-to-9.20.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LZMA-SDK-9.11-to-9.20.json",
-      "referenceNumber": 271,
+      "referenceNumber": 414,
       "name": "LZMA SDK License (versions 9.11 to 9.20)",
       "licenseId": "LZMA-SDK-9.11-to-9.20",
       "seeAlso": [
@@ -4944,7 +5328,7 @@
       "reference": "https://spdx.org/licenses/LZMA-SDK-9.22.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LZMA-SDK-9.22.json",
-      "referenceNumber": 480,
+      "referenceNumber": 288,
       "name": "LZMA SDK License (versions 9.22 and beyond)",
       "licenseId": "LZMA-SDK-9.22",
       "seeAlso": [
@@ -4957,7 +5341,7 @@
       "reference": "https://spdx.org/licenses/Mackerras-3-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Mackerras-3-Clause.json",
-      "referenceNumber": 165,
+      "referenceNumber": 296,
       "name": "Mackerras 3-Clause License",
       "licenseId": "Mackerras-3-Clause",
       "seeAlso": [
@@ -4969,7 +5353,7 @@
       "reference": "https://spdx.org/licenses/Mackerras-3-Clause-acknowledgment.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Mackerras-3-Clause-acknowledgment.json",
-      "referenceNumber": 575,
+      "referenceNumber": 302,
       "name": "Mackerras 3-Clause - acknowledgment variant",
       "licenseId": "Mackerras-3-Clause-acknowledgment",
       "seeAlso": [
@@ -4981,11 +5365,12 @@
       "reference": "https://spdx.org/licenses/magaz.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/magaz.json",
-      "referenceNumber": 164,
+      "referenceNumber": 590,
       "name": "magaz License",
       "licenseId": "magaz",
       "seeAlso": [
-        "https://mirrors.nic.cz/tex-archive/macros/latex/contrib/magaz/magaz.tex"
+        "https://mirrors.nic.cz/tex-archive/macros/latex/contrib/magaz/magaz.tex",
+        "https://mirrors.ctan.org/macros/latex/contrib/version/version.sty"
       ],
       "isOsiApproved": false
     },
@@ -4993,7 +5378,7 @@
       "reference": "https://spdx.org/licenses/mailprio.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/mailprio.json",
-      "referenceNumber": 210,
+      "referenceNumber": 689,
       "name": "mailprio License",
       "licenseId": "mailprio",
       "seeAlso": [
@@ -5005,7 +5390,7 @@
       "reference": "https://spdx.org/licenses/MakeIndex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MakeIndex.json",
-      "referenceNumber": 227,
+      "referenceNumber": 556,
       "name": "MakeIndex License",
       "licenseId": "MakeIndex",
       "seeAlso": [
@@ -5014,10 +5399,24 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/man2html.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/man2html.json",
+      "referenceNumber": 268,
+      "name": "man2html License",
+      "licenseId": "man2html",
+      "seeAlso": [
+        "http://primates.ximian.com/~flucifredi/man/man-1.6g.tar.gz",
+        "https://github.com/hamano/man2html/blob/master/man2html.c",
+        "https://docs.oracle.com/cd/E81115_01/html/E81116/licenses.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/Martin-Birgmeier.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Martin-Birgmeier.json",
-      "referenceNumber": 582,
+      "referenceNumber": 687,
       "name": "Martin Birgmeier License",
       "licenseId": "Martin-Birgmeier",
       "seeAlso": [
@@ -5029,7 +5428,7 @@
       "reference": "https://spdx.org/licenses/McPhee-slideshow.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/McPhee-slideshow.json",
-      "referenceNumber": 212,
+      "referenceNumber": 576,
       "name": "McPhee Slideshow License",
       "licenseId": "McPhee-slideshow",
       "seeAlso": [
@@ -5041,7 +5440,7 @@
       "reference": "https://spdx.org/licenses/metamail.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/metamail.json",
-      "referenceNumber": 391,
+      "referenceNumber": 605,
       "name": "metamail License",
       "licenseId": "metamail",
       "seeAlso": [
@@ -5053,7 +5452,7 @@
       "reference": "https://spdx.org/licenses/Minpack.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Minpack.json",
-      "referenceNumber": 648,
+      "referenceNumber": 163,
       "name": "Minpack License",
       "licenseId": "Minpack",
       "seeAlso": [
@@ -5063,10 +5462,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/MIPS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIPS.json",
+      "referenceNumber": 114,
+      "name": "MIPS License",
+      "licenseId": "MIPS",
+      "seeAlso": [
+        "https://sourceware.org/cgit/binutils-gdb/tree/include/coff/sym.h#n11"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/MirOS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MirOS.json",
-      "referenceNumber": 153,
+      "referenceNumber": 264,
       "name": "The MirOS Licence",
       "licenseId": "MirOS",
       "seeAlso": [
@@ -5078,11 +5489,12 @@
       "reference": "https://spdx.org/licenses/MIT.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT.json",
-      "referenceNumber": 544,
+      "referenceNumber": 149,
       "name": "MIT License",
       "licenseId": "MIT",
       "seeAlso": [
-        "https://opensource.org/license/mit/"
+        "https://opensource.org/license/mit/",
+        "http://opensource.org/licenses/MIT"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -5091,7 +5503,7 @@
       "reference": "https://spdx.org/licenses/MIT-0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-0.json",
-      "referenceNumber": 366,
+      "referenceNumber": 77,
       "name": "MIT No Attribution",
       "licenseId": "MIT-0",
       "seeAlso": [
@@ -5105,7 +5517,7 @@
       "reference": "https://spdx.org/licenses/MIT-advertising.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-advertising.json",
-      "referenceNumber": 184,
+      "referenceNumber": 693,
       "name": "Enlightenment License (e16)",
       "licenseId": "MIT-advertising",
       "seeAlso": [
@@ -5114,10 +5526,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/MIT-Click.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-Click.json",
+      "referenceNumber": 580,
+      "name": "MIT Click License",
+      "licenseId": "MIT-Click",
+      "seeAlso": [
+        "https://github.com/kohler/t1utils/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/MIT-CMU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-CMU.json",
-      "referenceNumber": 321,
+      "referenceNumber": 671,
       "name": "CMU License",
       "licenseId": "MIT-CMU",
       "seeAlso": [
@@ -5130,7 +5554,7 @@
       "reference": "https://spdx.org/licenses/MIT-enna.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-enna.json",
-      "referenceNumber": 494,
+      "referenceNumber": 205,
       "name": "enna License",
       "licenseId": "MIT-enna",
       "seeAlso": [
@@ -5142,7 +5566,7 @@
       "reference": "https://spdx.org/licenses/MIT-feh.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-feh.json",
-      "referenceNumber": 127,
+      "referenceNumber": 520,
       "name": "feh License",
       "licenseId": "MIT-feh",
       "seeAlso": [
@@ -5154,7 +5578,7 @@
       "reference": "https://spdx.org/licenses/MIT-Festival.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-Festival.json",
-      "referenceNumber": 615,
+      "referenceNumber": 477,
       "name": "MIT Festival Variant",
       "licenseId": "MIT-Festival",
       "seeAlso": [
@@ -5167,7 +5591,7 @@
       "reference": "https://spdx.org/licenses/MIT-Khronos-old.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-Khronos-old.json",
-      "referenceNumber": 520,
+      "referenceNumber": 541,
       "name": "MIT Khronos - old variant",
       "licenseId": "MIT-Khronos-old",
       "seeAlso": [
@@ -5179,7 +5603,7 @@
       "reference": "https://spdx.org/licenses/MIT-Modern-Variant.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-Modern-Variant.json",
-      "referenceNumber": 116,
+      "referenceNumber": 484,
       "name": "MIT License Modern Variant",
       "licenseId": "MIT-Modern-Variant",
       "seeAlso": [
@@ -5193,12 +5617,11 @@
       "reference": "https://spdx.org/licenses/MIT-open-group.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-open-group.json",
-      "referenceNumber": 226,
+      "referenceNumber": 443,
       "name": "MIT Open Group variant",
       "licenseId": "MIT-open-group",
       "seeAlso": [
         "https://gitlab.freedesktop.org/xorg/app/iceauth/-/blob/master/COPYING",
-        "https://gitlab.freedesktop.org/xorg/app/xvinfo/-/blob/master/COPYING",
         "https://gitlab.freedesktop.org/xorg/app/xsetroot/-/blob/master/COPYING",
         "https://gitlab.freedesktop.org/xorg/app/xauth/-/blob/master/COPYING"
       ],
@@ -5208,7 +5631,7 @@
       "reference": "https://spdx.org/licenses/MIT-testregex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-testregex.json",
-      "referenceNumber": 144,
+      "referenceNumber": 586,
       "name": "MIT testregex Variant",
       "licenseId": "MIT-testregex",
       "seeAlso": [
@@ -5220,7 +5643,7 @@
       "reference": "https://spdx.org/licenses/MIT-Wu.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-Wu.json",
-      "referenceNumber": 512,
+      "referenceNumber": 61,
       "name": "MIT Tom Wu Variant",
       "licenseId": "MIT-Wu",
       "seeAlso": [
@@ -5232,7 +5655,7 @@
       "reference": "https://spdx.org/licenses/MITNFA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MITNFA.json",
-      "referenceNumber": 286,
+      "referenceNumber": 279,
       "name": "MIT +no-false-attribs license",
       "licenseId": "MITNFA",
       "seeAlso": [
@@ -5244,7 +5667,7 @@
       "reference": "https://spdx.org/licenses/MMIXware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MMIXware.json",
-      "referenceNumber": 10,
+      "referenceNumber": 595,
       "name": "MMIXware License",
       "licenseId": "MMIXware",
       "seeAlso": [
@@ -5256,7 +5679,7 @@
       "reference": "https://spdx.org/licenses/Motosoto.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Motosoto.json",
-      "referenceNumber": 40,
+      "referenceNumber": 543,
       "name": "Motosoto License",
       "licenseId": "Motosoto",
       "seeAlso": [
@@ -5268,7 +5691,7 @@
       "reference": "https://spdx.org/licenses/MPEG-SSG.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPEG-SSG.json",
-      "referenceNumber": 195,
+      "referenceNumber": 546,
       "name": "MPEG Software Simulation",
       "licenseId": "MPEG-SSG",
       "seeAlso": [
@@ -5280,7 +5703,7 @@
       "reference": "https://spdx.org/licenses/mpi-permissive.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/mpi-permissive.json",
-      "referenceNumber": 291,
+      "referenceNumber": 11,
       "name": "mpi Permissive License",
       "licenseId": "mpi-permissive",
       "seeAlso": [
@@ -5292,7 +5715,7 @@
       "reference": "https://spdx.org/licenses/mpich2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/mpich2.json",
-      "referenceNumber": 149,
+      "referenceNumber": 285,
       "name": "mpich2 License",
       "licenseId": "mpich2",
       "seeAlso": [
@@ -5304,7 +5727,7 @@
       "reference": "https://spdx.org/licenses/MPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPL-1.0.json",
-      "referenceNumber": 497,
+      "referenceNumber": 123,
       "name": "Mozilla Public License 1.0",
       "licenseId": "MPL-1.0",
       "seeAlso": [
@@ -5317,7 +5740,7 @@
       "reference": "https://spdx.org/licenses/MPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPL-1.1.json",
-      "referenceNumber": 625,
+      "referenceNumber": 538,
       "name": "Mozilla Public License 1.1",
       "licenseId": "MPL-1.1",
       "seeAlso": [
@@ -5331,7 +5754,7 @@
       "reference": "https://spdx.org/licenses/MPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPL-2.0.json",
-      "referenceNumber": 117,
+      "referenceNumber": 281,
       "name": "Mozilla Public License 2.0",
       "licenseId": "MPL-2.0",
       "seeAlso": [
@@ -5345,7 +5768,7 @@
       "reference": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
-      "referenceNumber": 586,
+      "referenceNumber": 404,
       "name": "Mozilla Public License 2.0 (no copyleft exception)",
       "licenseId": "MPL-2.0-no-copyleft-exception",
       "seeAlso": [
@@ -5358,7 +5781,7 @@
       "reference": "https://spdx.org/licenses/mplus.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/mplus.json",
-      "referenceNumber": 637,
+      "referenceNumber": 256,
       "name": "mplus Font License",
       "licenseId": "mplus",
       "seeAlso": [
@@ -5370,7 +5793,7 @@
       "reference": "https://spdx.org/licenses/MS-LPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MS-LPL.json",
-      "referenceNumber": 254,
+      "referenceNumber": 70,
       "name": "Microsoft Limited Public License",
       "licenseId": "MS-LPL",
       "seeAlso": [
@@ -5384,7 +5807,7 @@
       "reference": "https://spdx.org/licenses/MS-PL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MS-PL.json",
-      "referenceNumber": 143,
+      "referenceNumber": 609,
       "name": "Microsoft Public License",
       "licenseId": "MS-PL",
       "seeAlso": [
@@ -5398,7 +5821,7 @@
       "reference": "https://spdx.org/licenses/MS-RL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MS-RL.json",
-      "referenceNumber": 311,
+      "referenceNumber": 652,
       "name": "Microsoft Reciprocal License",
       "licenseId": "MS-RL",
       "seeAlso": [
@@ -5412,7 +5835,7 @@
       "reference": "https://spdx.org/licenses/MTLL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MTLL.json",
-      "referenceNumber": 268,
+      "referenceNumber": 137,
       "name": "Matrix Template Library License",
       "licenseId": "MTLL",
       "seeAlso": [
@@ -5424,7 +5847,7 @@
       "reference": "https://spdx.org/licenses/MulanPSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MulanPSL-1.0.json",
-      "referenceNumber": 603,
+      "referenceNumber": 413,
       "name": "Mulan Permissive Software License, Version 1",
       "licenseId": "MulanPSL-1.0",
       "seeAlso": [
@@ -5437,7 +5860,7 @@
       "reference": "https://spdx.org/licenses/MulanPSL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MulanPSL-2.0.json",
-      "referenceNumber": 125,
+      "referenceNumber": 424,
       "name": "Mulan Permissive Software License, Version 2",
       "licenseId": "MulanPSL-2.0",
       "seeAlso": [
@@ -5449,7 +5872,7 @@
       "reference": "https://spdx.org/licenses/Multics.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Multics.json",
-      "referenceNumber": 168,
+      "referenceNumber": 66,
       "name": "Multics License",
       "licenseId": "Multics",
       "seeAlso": [
@@ -5461,7 +5884,7 @@
       "reference": "https://spdx.org/licenses/Mup.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Mup.json",
-      "referenceNumber": 390,
+      "referenceNumber": 398,
       "name": "Mup License",
       "licenseId": "Mup",
       "seeAlso": [
@@ -5473,7 +5896,7 @@
       "reference": "https://spdx.org/licenses/NAIST-2003.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NAIST-2003.json",
-      "referenceNumber": 407,
+      "referenceNumber": 616,
       "name": "Nara Institute of Science and Technology License (2003)",
       "licenseId": "NAIST-2003",
       "seeAlso": [
@@ -5486,7 +5909,7 @@
       "reference": "https://spdx.org/licenses/NASA-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NASA-1.3.json",
-      "referenceNumber": 14,
+      "referenceNumber": 43,
       "name": "NASA Open Source Agreement 1.3",
       "licenseId": "NASA-1.3",
       "seeAlso": [
@@ -5500,7 +5923,7 @@
       "reference": "https://spdx.org/licenses/Naumen.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Naumen.json",
-      "referenceNumber": 620,
+      "referenceNumber": 391,
       "name": "Naumen Public License",
       "licenseId": "Naumen",
       "seeAlso": [
@@ -5512,7 +5935,7 @@
       "reference": "https://spdx.org/licenses/NBPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NBPL-1.0.json",
-      "referenceNumber": 492,
+      "referenceNumber": 591,
       "name": "Net Boolean Public License v1",
       "licenseId": "NBPL-1.0",
       "seeAlso": [
@@ -5521,10 +5944,26 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/NCBI-PD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NCBI-PD.json",
+      "referenceNumber": 176,
+      "name": "NCBI Public Domain Notice",
+      "licenseId": "NCBI-PD",
+      "seeAlso": [
+        "https://github.com/ncbi/sra-tools/blob/e8e5b6af4edc460156ad9ce5902d0779cffbf685/LICENSE",
+        "https://github.com/ncbi/datasets/blob/0ea4cd16b61e5b799d9cc55aecfa016d6c9bd2bf/LICENSE.md",
+        "https://github.com/ncbi/gprobe/blob/de64d30fee8b4c4013094d7d3139ea89b5dd1ace/LICENSE",
+        "https://github.com/ncbi/egapx/blob/08930b9dec0c69b2d1a05e5153c7b95ef0a3eb0f/LICENSE",
+        "https://github.com/ncbi/datasets/blob/master/LICENSE.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/NCGL-UK-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NCGL-UK-2.0.json",
-      "referenceNumber": 614,
+      "referenceNumber": 452,
       "name": "Non-Commercial Government Licence",
       "licenseId": "NCGL-UK-2.0",
       "seeAlso": [
@@ -5536,7 +5975,7 @@
       "reference": "https://spdx.org/licenses/NCL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NCL.json",
-      "referenceNumber": 555,
+      "referenceNumber": 679,
       "name": "NCL Source Code License",
       "licenseId": "NCL",
       "seeAlso": [
@@ -5548,7 +5987,7 @@
       "reference": "https://spdx.org/licenses/NCSA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NCSA.json",
-      "referenceNumber": 110,
+      "referenceNumber": 107,
       "name": "University of Illinois/NCSA Open Source License",
       "licenseId": "NCSA",
       "seeAlso": [
@@ -5560,9 +5999,9 @@
     },
     {
       "reference": "https://spdx.org/licenses/Net-SNMP.html",
-      "isDeprecatedLicenseId": false,
+      "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/Net-SNMP.json",
-      "referenceNumber": 26,
+      "referenceNumber": 685,
       "name": "Net-SNMP License",
       "licenseId": "Net-SNMP",
       "seeAlso": [
@@ -5574,7 +6013,7 @@
       "reference": "https://spdx.org/licenses/NetCDF.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NetCDF.json",
-      "referenceNumber": 339,
+      "referenceNumber": 578,
       "name": "NetCDF license",
       "licenseId": "NetCDF",
       "seeAlso": [
@@ -5586,7 +6025,7 @@
       "reference": "https://spdx.org/licenses/Newsletr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Newsletr.json",
-      "referenceNumber": 315,
+      "referenceNumber": 57,
       "name": "Newsletr License",
       "licenseId": "Newsletr",
       "seeAlso": [
@@ -5598,7 +6037,7 @@
       "reference": "https://spdx.org/licenses/NGPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NGPL.json",
-      "referenceNumber": 401,
+      "referenceNumber": 678,
       "name": "Nethack General Public License",
       "licenseId": "NGPL",
       "seeAlso": [
@@ -5607,10 +6046,22 @@
       "isOsiApproved": true
     },
     {
+      "reference": "https://spdx.org/licenses/ngrep.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ngrep.json",
+      "referenceNumber": 338,
+      "name": "ngrep License",
+      "licenseId": "ngrep",
+      "seeAlso": [
+        "https://github.com/jpr5/ngrep/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/NICTA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NICTA-1.0.json",
-      "referenceNumber": 388,
+      "referenceNumber": 566,
       "name": "NICTA Public Software License, Version 1.0",
       "licenseId": "NICTA-1.0",
       "seeAlso": [
@@ -5622,7 +6073,7 @@
       "reference": "https://spdx.org/licenses/NIST-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NIST-PD.json",
-      "referenceNumber": 378,
+      "referenceNumber": 393,
       "name": "NIST Public Domain Notice",
       "licenseId": "NIST-PD",
       "seeAlso": [
@@ -5635,7 +6086,7 @@
       "reference": "https://spdx.org/licenses/NIST-PD-fallback.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NIST-PD-fallback.json",
-      "referenceNumber": 444,
+      "referenceNumber": 230,
       "name": "NIST Public Domain Notice with license fallback",
       "licenseId": "NIST-PD-fallback",
       "seeAlso": [
@@ -5648,7 +6099,7 @@
       "reference": "https://spdx.org/licenses/NIST-Software.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NIST-Software.json",
-      "referenceNumber": 196,
+      "referenceNumber": 121,
       "name": "NIST Software License",
       "licenseId": "NIST-Software",
       "seeAlso": [
@@ -5660,7 +6111,7 @@
       "reference": "https://spdx.org/licenses/NLOD-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NLOD-1.0.json",
-      "referenceNumber": 422,
+      "referenceNumber": 272,
       "name": "Norwegian Licence for Open Government Data (NLOD) 1.0",
       "licenseId": "NLOD-1.0",
       "seeAlso": [
@@ -5672,7 +6123,7 @@
       "reference": "https://spdx.org/licenses/NLOD-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NLOD-2.0.json",
-      "referenceNumber": 56,
+      "referenceNumber": 229,
       "name": "Norwegian Licence for Open Government Data (NLOD) 2.0",
       "licenseId": "NLOD-2.0",
       "seeAlso": [
@@ -5684,7 +6135,7 @@
       "reference": "https://spdx.org/licenses/NLPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NLPL.json",
-      "referenceNumber": 628,
+      "referenceNumber": 696,
       "name": "No Limit Public License",
       "licenseId": "NLPL",
       "seeAlso": [
@@ -5696,7 +6147,7 @@
       "reference": "https://spdx.org/licenses/Nokia.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Nokia.json",
-      "referenceNumber": 290,
+      "referenceNumber": 366,
       "name": "Nokia Open Source License",
       "licenseId": "Nokia",
       "seeAlso": [
@@ -5709,7 +6160,7 @@
       "reference": "https://spdx.org/licenses/NOSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NOSL.json",
-      "referenceNumber": 410,
+      "referenceNumber": 118,
       "name": "Netizen Open Source License",
       "licenseId": "NOSL",
       "seeAlso": [
@@ -5722,7 +6173,7 @@
       "reference": "https://spdx.org/licenses/Noweb.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Noweb.json",
-      "referenceNumber": 481,
+      "referenceNumber": 377,
       "name": "Noweb License",
       "licenseId": "Noweb",
       "seeAlso": [
@@ -5734,7 +6185,7 @@
       "reference": "https://spdx.org/licenses/NPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NPL-1.0.json",
-      "referenceNumber": 392,
+      "referenceNumber": 168,
       "name": "Netscape Public License v1.0",
       "licenseId": "NPL-1.0",
       "seeAlso": [
@@ -5747,7 +6198,7 @@
       "reference": "https://spdx.org/licenses/NPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NPL-1.1.json",
-      "referenceNumber": 525,
+      "referenceNumber": 419,
       "name": "Netscape Public License v1.1",
       "licenseId": "NPL-1.1",
       "seeAlso": [
@@ -5760,7 +6211,7 @@
       "reference": "https://spdx.org/licenses/NPOSL-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NPOSL-3.0.json",
-      "referenceNumber": 487,
+      "referenceNumber": 401,
       "name": "Non-Profit Open Software License 3.0",
       "licenseId": "NPOSL-3.0",
       "seeAlso": [
@@ -5772,7 +6223,7 @@
       "reference": "https://spdx.org/licenses/NRL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NRL.json",
-      "referenceNumber": 323,
+      "referenceNumber": 6,
       "name": "NRL License",
       "licenseId": "NRL",
       "seeAlso": [
@@ -5781,10 +6232,23 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/NTIA-PD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NTIA-PD.json",
+      "referenceNumber": 587,
+      "name": "NTIA Public Domain Notice",
+      "licenseId": "NTIA-PD",
+      "seeAlso": [
+        "https://raw.githubusercontent.com/NTIA/itm/refs/heads/master/LICENSE.md",
+        "https://raw.githubusercontent.com/NTIA/scos-sensor/refs/heads/master/LICENSE.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/NTP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NTP.json",
-      "referenceNumber": 123,
+      "referenceNumber": 24,
       "name": "NTP License",
       "licenseId": "NTP",
       "seeAlso": [
@@ -5796,7 +6260,7 @@
       "reference": "https://spdx.org/licenses/NTP-0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NTP-0.json",
-      "referenceNumber": 232,
+      "referenceNumber": 286,
       "name": "NTP No Attribution",
       "licenseId": "NTP-0",
       "seeAlso": [
@@ -5808,7 +6272,7 @@
       "reference": "https://spdx.org/licenses/Nunit.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/Nunit.json",
-      "referenceNumber": 340,
+      "referenceNumber": 606,
       "name": "Nunit License",
       "licenseId": "Nunit",
       "seeAlso": [
@@ -5821,7 +6285,7 @@
       "reference": "https://spdx.org/licenses/O-UDA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/O-UDA-1.0.json",
-      "referenceNumber": 598,
+      "referenceNumber": 159,
       "name": "Open Use of Data Agreement v1.0",
       "licenseId": "O-UDA-1.0",
       "seeAlso": [
@@ -5834,7 +6298,7 @@
       "reference": "https://spdx.org/licenses/OAR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OAR.json",
-      "referenceNumber": 500,
+      "referenceNumber": 128,
       "name": "OAR License",
       "licenseId": "OAR",
       "seeAlso": [
@@ -5846,7 +6310,7 @@
       "reference": "https://spdx.org/licenses/OCCT-PL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OCCT-PL.json",
-      "referenceNumber": 137,
+      "referenceNumber": 106,
       "name": "Open CASCADE Technology Public License",
       "licenseId": "OCCT-PL",
       "seeAlso": [
@@ -5858,7 +6322,7 @@
       "reference": "https://spdx.org/licenses/OCLC-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OCLC-2.0.json",
-      "referenceNumber": 250,
+      "referenceNumber": 694,
       "name": "OCLC Research Public License 2.0",
       "licenseId": "OCLC-2.0",
       "seeAlso": [
@@ -5871,7 +6335,7 @@
       "reference": "https://spdx.org/licenses/ODbL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ODbL-1.0.json",
-      "referenceNumber": 358,
+      "referenceNumber": 94,
       "name": "Open Data Commons Open Database License v1.0",
       "licenseId": "ODbL-1.0",
       "seeAlso": [
@@ -5885,7 +6349,7 @@
       "reference": "https://spdx.org/licenses/ODC-By-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ODC-By-1.0.json",
-      "referenceNumber": 166,
+      "referenceNumber": 276,
       "name": "Open Data Commons Attribution License v1.0",
       "licenseId": "ODC-By-1.0",
       "seeAlso": [
@@ -5897,7 +6361,7 @@
       "reference": "https://spdx.org/licenses/OFFIS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFFIS.json",
-      "referenceNumber": 245,
+      "referenceNumber": 459,
       "name": "OFFIS License",
       "licenseId": "OFFIS",
       "seeAlso": [
@@ -5909,7 +6373,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.0.json",
-      "referenceNumber": 1,
+      "referenceNumber": 645,
       "name": "SIL Open Font License 1.0",
       "licenseId": "OFL-1.0",
       "seeAlso": [
@@ -5922,7 +6386,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.0-no-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.0-no-RFN.json",
-      "referenceNumber": 214,
+      "referenceNumber": 644,
       "name": "SIL Open Font License 1.0 with no Reserved Font Name",
       "licenseId": "OFL-1.0-no-RFN",
       "seeAlso": [
@@ -5934,7 +6398,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.0-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.0-RFN.json",
-      "referenceNumber": 73,
+      "referenceNumber": 233,
       "name": "SIL Open Font License 1.0 with Reserved Font Name",
       "licenseId": "OFL-1.0-RFN",
       "seeAlso": [
@@ -5946,7 +6410,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.1.json",
-      "referenceNumber": 188,
+      "referenceNumber": 480,
       "name": "SIL Open Font License 1.1",
       "licenseId": "OFL-1.1",
       "seeAlso": [
@@ -5960,7 +6424,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.1-no-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.1-no-RFN.json",
-      "referenceNumber": 436,
+      "referenceNumber": 544,
       "name": "SIL Open Font License 1.1 with no Reserved Font Name",
       "licenseId": "OFL-1.1-no-RFN",
       "seeAlso": [
@@ -5973,7 +6437,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.1-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.1-RFN.json",
-      "referenceNumber": 528,
+      "referenceNumber": 170,
       "name": "SIL Open Font License 1.1 with Reserved Font Name",
       "licenseId": "OFL-1.1-RFN",
       "seeAlso": [
@@ -5986,7 +6450,7 @@
       "reference": "https://spdx.org/licenses/OGC-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGC-1.0.json",
-      "referenceNumber": 511,
+      "referenceNumber": 109,
       "name": "OGC Software License, Version 1.0",
       "licenseId": "OGC-1.0",
       "seeAlso": [
@@ -5998,7 +6462,7 @@
       "reference": "https://spdx.org/licenses/OGDL-Taiwan-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGDL-Taiwan-1.0.json",
-      "referenceNumber": 199,
+      "referenceNumber": 579,
       "name": "Taiwan Open Government Data License, version 1.0",
       "licenseId": "OGDL-Taiwan-1.0",
       "seeAlso": [
@@ -6010,7 +6474,7 @@
       "reference": "https://spdx.org/licenses/OGL-Canada-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGL-Canada-2.0.json",
-      "referenceNumber": 265,
+      "referenceNumber": 126,
       "name": "Open Government Licence - Canada",
       "licenseId": "OGL-Canada-2.0",
       "seeAlso": [
@@ -6022,7 +6486,7 @@
       "reference": "https://spdx.org/licenses/OGL-UK-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGL-UK-1.0.json",
-      "referenceNumber": 382,
+      "referenceNumber": 45,
       "name": "Open Government Licence v1.0",
       "licenseId": "OGL-UK-1.0",
       "seeAlso": [
@@ -6034,7 +6498,7 @@
       "reference": "https://spdx.org/licenses/OGL-UK-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGL-UK-2.0.json",
-      "referenceNumber": 515,
+      "referenceNumber": 112,
       "name": "Open Government Licence v2.0",
       "licenseId": "OGL-UK-2.0",
       "seeAlso": [
@@ -6046,7 +6510,7 @@
       "reference": "https://spdx.org/licenses/OGL-UK-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGL-UK-3.0.json",
-      "referenceNumber": 367,
+      "referenceNumber": 444,
       "name": "Open Government Licence v3.0",
       "licenseId": "OGL-UK-3.0",
       "seeAlso": [
@@ -6058,7 +6522,7 @@
       "reference": "https://spdx.org/licenses/OGTSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGTSL.json",
-      "referenceNumber": 506,
+      "referenceNumber": 637,
       "name": "Open Group Test Suite License",
       "licenseId": "OGTSL",
       "seeAlso": [
@@ -6071,7 +6535,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-1.1.json",
-      "referenceNumber": 428,
+      "referenceNumber": 119,
       "name": "Open LDAP Public License v1.1",
       "licenseId": "OLDAP-1.1",
       "seeAlso": [
@@ -6083,7 +6547,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-1.2.json",
-      "referenceNumber": 445,
+      "referenceNumber": 227,
       "name": "Open LDAP Public License v1.2",
       "licenseId": "OLDAP-1.2",
       "seeAlso": [
@@ -6095,7 +6559,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-1.3.json",
-      "referenceNumber": 30,
+      "referenceNumber": 130,
       "name": "Open LDAP Public License v1.3",
       "licenseId": "OLDAP-1.3",
       "seeAlso": [
@@ -6107,7 +6571,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-1.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-1.4.json",
-      "referenceNumber": 346,
+      "referenceNumber": 183,
       "name": "Open LDAP Public License v1.4",
       "licenseId": "OLDAP-1.4",
       "seeAlso": [
@@ -6119,7 +6583,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.0.json",
-      "referenceNumber": 253,
+      "referenceNumber": 559,
       "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
       "licenseId": "OLDAP-2.0",
       "seeAlso": [
@@ -6131,7 +6595,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.0.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.0.1.json",
-      "referenceNumber": 120,
+      "referenceNumber": 583,
       "name": "Open LDAP Public License v2.0.1",
       "licenseId": "OLDAP-2.0.1",
       "seeAlso": [
@@ -6143,7 +6607,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.1.json",
-      "referenceNumber": 502,
+      "referenceNumber": 451,
       "name": "Open LDAP Public License v2.1",
       "licenseId": "OLDAP-2.1",
       "seeAlso": [
@@ -6155,7 +6619,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.json",
-      "referenceNumber": 239,
+      "referenceNumber": 357,
       "name": "Open LDAP Public License v2.2",
       "licenseId": "OLDAP-2.2",
       "seeAlso": [
@@ -6167,7 +6631,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.1.json",
-      "referenceNumber": 319,
+      "referenceNumber": 635,
       "name": "Open LDAP Public License v2.2.1",
       "licenseId": "OLDAP-2.2.1",
       "seeAlso": [
@@ -6179,7 +6643,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.2.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.2.json",
-      "referenceNumber": 630,
+      "referenceNumber": 684,
       "name": "Open LDAP Public License 2.2.2",
       "licenseId": "OLDAP-2.2.2",
       "seeAlso": [
@@ -6191,7 +6655,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.3.json",
-      "referenceNumber": 639,
+      "referenceNumber": 189,
       "name": "Open LDAP Public License v2.3",
       "licenseId": "OLDAP-2.3",
       "seeAlso": [
@@ -6204,7 +6668,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.4.json",
-      "referenceNumber": 606,
+      "referenceNumber": 222,
       "name": "Open LDAP Public License v2.4",
       "licenseId": "OLDAP-2.4",
       "seeAlso": [
@@ -6216,7 +6680,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.5.json",
-      "referenceNumber": 651,
+      "referenceNumber": 699,
       "name": "Open LDAP Public License v2.5",
       "licenseId": "OLDAP-2.5",
       "seeAlso": [
@@ -6228,7 +6692,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.6.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.6.json",
-      "referenceNumber": 115,
+      "referenceNumber": 270,
       "name": "Open LDAP Public License v2.6",
       "licenseId": "OLDAP-2.6",
       "seeAlso": [
@@ -6240,7 +6704,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.7.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.7.json",
-      "referenceNumber": 469,
+      "referenceNumber": 265,
       "name": "Open LDAP Public License v2.7",
       "licenseId": "OLDAP-2.7",
       "seeAlso": [
@@ -6253,7 +6717,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.8.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.8.json",
-      "referenceNumber": 122,
+      "referenceNumber": 593,
       "name": "Open LDAP Public License v2.8",
       "licenseId": "OLDAP-2.8",
       "seeAlso": [
@@ -6265,7 +6729,7 @@
       "reference": "https://spdx.org/licenses/OLFL-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLFL-1.3.json",
-      "referenceNumber": 509,
+      "referenceNumber": 455,
       "name": "Open Logistics Foundation License Version 1.3",
       "licenseId": "OLFL-1.3",
       "seeAlso": [
@@ -6278,7 +6742,7 @@
       "reference": "https://spdx.org/licenses/OML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OML.json",
-      "referenceNumber": 24,
+      "referenceNumber": 446,
       "name": "Open Market License",
       "licenseId": "OML",
       "seeAlso": [
@@ -6290,7 +6754,7 @@
       "reference": "https://spdx.org/licenses/OpenPBS-2.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OpenPBS-2.3.json",
-      "referenceNumber": 328,
+      "referenceNumber": 400,
       "name": "OpenPBS v2.3 Software License",
       "licenseId": "OpenPBS-2.3",
       "seeAlso": [
@@ -6303,7 +6767,7 @@
       "reference": "https://spdx.org/licenses/OpenSSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OpenSSL.json",
-      "referenceNumber": 183,
+      "referenceNumber": 104,
       "name": "OpenSSL License",
       "licenseId": "OpenSSL",
       "seeAlso": [
@@ -6316,7 +6780,7 @@
       "reference": "https://spdx.org/licenses/OpenSSL-standalone.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OpenSSL-standalone.json",
-      "referenceNumber": 624,
+      "referenceNumber": 698,
       "name": "OpenSSL License - standalone",
       "licenseId": "OpenSSL-standalone",
       "seeAlso": [
@@ -6329,7 +6793,7 @@
       "reference": "https://spdx.org/licenses/OpenVision.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OpenVision.json",
-      "referenceNumber": 579,
+      "referenceNumber": 466,
       "name": "OpenVision License",
       "licenseId": "OpenVision",
       "seeAlso": [
@@ -6343,7 +6807,7 @@
       "reference": "https://spdx.org/licenses/OPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OPL-1.0.json",
-      "referenceNumber": 61,
+      "referenceNumber": 522,
       "name": "Open Public License v1.0",
       "licenseId": "OPL-1.0",
       "seeAlso": [
@@ -6357,7 +6821,7 @@
       "reference": "https://spdx.org/licenses/OPL-UK-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OPL-UK-3.0.json",
-      "referenceNumber": 588,
+      "referenceNumber": 487,
       "name": "United    Kingdom Open Parliament Licence v3.0",
       "licenseId": "OPL-UK-3.0",
       "seeAlso": [
@@ -6369,7 +6833,7 @@
       "reference": "https://spdx.org/licenses/OPUBL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OPUBL-1.0.json",
-      "referenceNumber": 179,
+      "referenceNumber": 237,
       "name": "Open Publication License v1.0",
       "licenseId": "OPUBL-1.0",
       "seeAlso": [
@@ -6383,7 +6847,7 @@
       "reference": "https://spdx.org/licenses/OSET-PL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSET-PL-2.1.json",
-      "referenceNumber": 565,
+      "referenceNumber": 395,
       "name": "OSET Public License version 2.1",
       "licenseId": "OSET-PL-2.1",
       "seeAlso": [
@@ -6396,7 +6860,7 @@
       "reference": "https://spdx.org/licenses/OSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-1.0.json",
-      "referenceNumber": 178,
+      "referenceNumber": 427,
       "name": "Open Software License 1.0",
       "licenseId": "OSL-1.0",
       "seeAlso": [
@@ -6409,7 +6873,7 @@
       "reference": "https://spdx.org/licenses/OSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-1.1.json",
-      "referenceNumber": 393,
+      "referenceNumber": 439,
       "name": "Open Software License 1.1",
       "licenseId": "OSL-1.1",
       "seeAlso": [
@@ -6422,7 +6886,7 @@
       "reference": "https://spdx.org/licenses/OSL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-2.0.json",
-      "referenceNumber": 192,
+      "referenceNumber": 181,
       "name": "Open Software License 2.0",
       "licenseId": "OSL-2.0",
       "seeAlso": [
@@ -6435,7 +6899,7 @@
       "reference": "https://spdx.org/licenses/OSL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-2.1.json",
-      "referenceNumber": 307,
+      "referenceNumber": 374,
       "name": "Open Software License 2.1",
       "licenseId": "OSL-2.1",
       "seeAlso": [
@@ -6449,7 +6913,7 @@
       "reference": "https://spdx.org/licenses/OSL-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-3.0.json",
-      "referenceNumber": 313,
+      "referenceNumber": 93,
       "name": "Open Software License 3.0",
       "licenseId": "OSL-3.0",
       "seeAlso": [
@@ -6463,7 +6927,7 @@
       "reference": "https://spdx.org/licenses/PADL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PADL.json",
-      "referenceNumber": 264,
+      "referenceNumber": 310,
       "name": "PADL License",
       "licenseId": "PADL",
       "seeAlso": [
@@ -6475,7 +6939,7 @@
       "reference": "https://spdx.org/licenses/Parity-6.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Parity-6.0.0.json",
-      "referenceNumber": 337,
+      "referenceNumber": 376,
       "name": "The Parity Public License 6.0.0",
       "licenseId": "Parity-6.0.0",
       "seeAlso": [
@@ -6487,7 +6951,7 @@
       "reference": "https://spdx.org/licenses/Parity-7.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Parity-7.0.0.json",
-      "referenceNumber": 170,
+      "referenceNumber": 117,
       "name": "The Parity Public License 7.0.0",
       "licenseId": "Parity-7.0.0",
       "seeAlso": [
@@ -6499,7 +6963,7 @@
       "reference": "https://spdx.org/licenses/PDDL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PDDL-1.0.json",
-      "referenceNumber": 542,
+      "referenceNumber": 506,
       "name": "Open Data Commons Public Domain Dedication \u0026 License 1.0",
       "licenseId": "PDDL-1.0",
       "seeAlso": [
@@ -6512,7 +6976,7 @@
       "reference": "https://spdx.org/licenses/PHP-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PHP-3.0.json",
-      "referenceNumber": 581,
+      "referenceNumber": 10,
       "name": "PHP License v3.0",
       "licenseId": "PHP-3.0",
       "seeAlso": [
@@ -6525,7 +6989,7 @@
       "reference": "https://spdx.org/licenses/PHP-3.01.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PHP-3.01.json",
-      "referenceNumber": 406,
+      "referenceNumber": 373,
       "name": "PHP License v3.01",
       "licenseId": "PHP-3.01",
       "seeAlso": [
@@ -6538,7 +7002,7 @@
       "reference": "https://spdx.org/licenses/Pixar.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Pixar.json",
-      "referenceNumber": 537,
+      "referenceNumber": 326,
       "name": "Pixar License",
       "licenseId": "Pixar",
       "seeAlso": [
@@ -6552,7 +7016,7 @@
       "reference": "https://spdx.org/licenses/pkgconf.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/pkgconf.json",
-      "referenceNumber": 347,
+      "referenceNumber": 592,
       "name": "pkgconf License",
       "licenseId": "pkgconf",
       "seeAlso": [
@@ -6564,7 +7028,7 @@
       "reference": "https://spdx.org/licenses/Plexus.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Plexus.json",
-      "referenceNumber": 163,
+      "referenceNumber": 458,
       "name": "Plexus Classworlds License",
       "licenseId": "Plexus",
       "seeAlso": [
@@ -6576,7 +7040,7 @@
       "reference": "https://spdx.org/licenses/pnmstitch.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/pnmstitch.json",
-      "referenceNumber": 129,
+      "referenceNumber": 561,
       "name": "pnmstitch License",
       "licenseId": "pnmstitch",
       "seeAlso": [
@@ -6588,7 +7052,7 @@
       "reference": "https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.json",
-      "referenceNumber": 585,
+      "referenceNumber": 320,
       "name": "PolyForm Noncommercial License 1.0.0",
       "licenseId": "PolyForm-Noncommercial-1.0.0",
       "seeAlso": [
@@ -6600,7 +7064,7 @@
       "reference": "https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.json",
-      "referenceNumber": 513,
+      "referenceNumber": 471,
       "name": "PolyForm Small Business License 1.0.0",
       "licenseId": "PolyForm-Small-Business-1.0.0",
       "seeAlso": [
@@ -6612,7 +7076,7 @@
       "reference": "https://spdx.org/licenses/PostgreSQL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PostgreSQL.json",
-      "referenceNumber": 364,
+      "referenceNumber": 572,
       "name": "PostgreSQL License",
       "licenseId": "PostgreSQL",
       "seeAlso": [
@@ -6625,7 +7089,7 @@
       "reference": "https://spdx.org/licenses/PPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PPL.json",
-      "referenceNumber": 531,
+      "referenceNumber": 525,
       "name": "Peer Production License",
       "licenseId": "PPL",
       "seeAlso": [
@@ -6639,11 +7103,12 @@
       "reference": "https://spdx.org/licenses/PSF-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PSF-2.0.json",
-      "referenceNumber": 623,
+      "referenceNumber": 269,
       "name": "Python Software Foundation License 2.0",
       "licenseId": "PSF-2.0",
       "seeAlso": [
-        "https://opensource.org/licenses/Python-2.0"
+        "https://opensource.org/licenses/Python-2.0",
+        "https://matplotlib.org/stable/project/license.html"
       ],
       "isOsiApproved": false
     },
@@ -6651,7 +7116,7 @@
       "reference": "https://spdx.org/licenses/psfrag.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/psfrag.json",
-      "referenceNumber": 383,
+      "referenceNumber": 603,
       "name": "psfrag License",
       "licenseId": "psfrag",
       "seeAlso": [
@@ -6663,7 +7128,7 @@
       "reference": "https://spdx.org/licenses/psutils.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/psutils.json",
-      "referenceNumber": 457,
+      "referenceNumber": 574,
       "name": "psutils License",
       "licenseId": "psutils",
       "seeAlso": [
@@ -6675,7 +7140,7 @@
       "reference": "https://spdx.org/licenses/Python-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Python-2.0.json",
-      "referenceNumber": 96,
+      "referenceNumber": 309,
       "name": "Python License 2.0",
       "licenseId": "Python-2.0",
       "seeAlso": [
@@ -6688,7 +7153,7 @@
       "reference": "https://spdx.org/licenses/Python-2.0.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Python-2.0.1.json",
-      "referenceNumber": 43,
+      "referenceNumber": 249,
       "name": "Python License 2.0.1",
       "licenseId": "Python-2.0.1",
       "seeAlso": [
@@ -6702,7 +7167,7 @@
       "reference": "https://spdx.org/licenses/python-ldap.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/python-ldap.json",
-      "referenceNumber": 107,
+      "referenceNumber": 85,
       "name": "Python ldap License",
       "licenseId": "python-ldap",
       "seeAlso": [
@@ -6714,7 +7179,7 @@
       "reference": "https://spdx.org/licenses/Qhull.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Qhull.json",
-      "referenceNumber": 485,
+      "referenceNumber": 47,
       "name": "Qhull License",
       "licenseId": "Qhull",
       "seeAlso": [
@@ -6726,7 +7191,7 @@
       "reference": "https://spdx.org/licenses/QPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/QPL-1.0.json",
-      "referenceNumber": 109,
+      "referenceNumber": 226,
       "name": "Q Public License 1.0",
       "licenseId": "QPL-1.0",
       "seeAlso": [
@@ -6741,7 +7206,7 @@
       "reference": "https://spdx.org/licenses/QPL-1.0-INRIA-2004.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/QPL-1.0-INRIA-2004.json",
-      "referenceNumber": 354,
+      "referenceNumber": 461,
       "name": "Q Public License 1.0 - INRIA 2004 variant",
       "licenseId": "QPL-1.0-INRIA-2004",
       "seeAlso": [
@@ -6753,7 +7218,7 @@
       "reference": "https://spdx.org/licenses/radvd.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/radvd.json",
-      "referenceNumber": 12,
+      "referenceNumber": 22,
       "name": "radvd License",
       "licenseId": "radvd",
       "seeAlso": [
@@ -6765,7 +7230,7 @@
       "reference": "https://spdx.org/licenses/Rdisc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Rdisc.json",
-      "referenceNumber": 467,
+      "referenceNumber": 258,
       "name": "Rdisc License",
       "licenseId": "Rdisc",
       "seeAlso": [
@@ -6777,7 +7242,7 @@
       "reference": "https://spdx.org/licenses/RHeCos-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RHeCos-1.1.json",
-      "referenceNumber": 484,
+      "referenceNumber": 29,
       "name": "Red Hat eCos Public License v1.1",
       "licenseId": "RHeCos-1.1",
       "seeAlso": [
@@ -6790,7 +7255,7 @@
       "reference": "https://spdx.org/licenses/RPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RPL-1.1.json",
-      "referenceNumber": 306,
+      "referenceNumber": 48,
       "name": "Reciprocal Public License 1.1",
       "licenseId": "RPL-1.1",
       "seeAlso": [
@@ -6802,7 +7267,7 @@
       "reference": "https://spdx.org/licenses/RPL-1.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RPL-1.5.json",
-      "referenceNumber": 102,
+      "referenceNumber": 562,
       "name": "Reciprocal Public License 1.5",
       "licenseId": "RPL-1.5",
       "seeAlso": [
@@ -6814,7 +7279,7 @@
       "reference": "https://spdx.org/licenses/RPSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RPSL-1.0.json",
-      "referenceNumber": 113,
+      "referenceNumber": 527,
       "name": "RealNetworks Public Source License v1.0",
       "licenseId": "RPSL-1.0",
       "seeAlso": [
@@ -6828,7 +7293,7 @@
       "reference": "https://spdx.org/licenses/RSA-MD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RSA-MD.json",
-      "referenceNumber": 501,
+      "referenceNumber": 73,
       "name": "RSA Message-Digest License",
       "licenseId": "RSA-MD",
       "seeAlso": [
@@ -6840,7 +7305,7 @@
       "reference": "https://spdx.org/licenses/RSCPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RSCPL.json",
-      "referenceNumber": 69,
+      "referenceNumber": 573,
       "name": "Ricoh Source Code Public License",
       "licenseId": "RSCPL",
       "seeAlso": [
@@ -6853,7 +7318,7 @@
       "reference": "https://spdx.org/licenses/Ruby.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Ruby.json",
-      "referenceNumber": 587,
+      "referenceNumber": 428,
       "name": "Ruby License",
       "licenseId": "Ruby",
       "seeAlso": [
@@ -6863,10 +7328,24 @@
       "isFsfLibre": true
     },
     {
+      "reference": "https://spdx.org/licenses/Ruby-pty.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Ruby-pty.json",
+      "referenceNumber": 407,
+      "name": "Ruby pty extension license",
+      "licenseId": "Ruby-pty",
+      "seeAlso": [
+        "https://github.com/ruby/ruby/blob/9f6deaa6888a423720b4b127b5314f0ad26cc2e6/ext/pty/pty.c#L775-L786",
+        "https://github.com/ruby/ruby/commit/0a64817fb80016030c03518fb9459f63c11605ea#diff-ef5fa30838d6d0cecad9e675cc50b24628cfe2cb277c346053fafcc36c91c204",
+        "https://github.com/ruby/ruby/commit/0a64817fb80016030c03518fb9459f63c11605ea#diff-fedf217c1ce44bda01f0a678d3ff8b198bed478754d699c527a698ad933979a0"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/SAX-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SAX-PD.json",
-      "referenceNumber": 138,
+      "referenceNumber": 654,
       "name": "Sax Public Domain Notice",
       "licenseId": "SAX-PD",
       "seeAlso": [
@@ -6878,7 +7357,7 @@
       "reference": "https://spdx.org/licenses/SAX-PD-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SAX-PD-2.0.json",
-      "referenceNumber": 219,
+      "referenceNumber": 690,
       "name": "Sax Public Domain Notice 2.0",
       "licenseId": "SAX-PD-2.0",
       "seeAlso": [
@@ -6890,7 +7369,7 @@
       "reference": "https://spdx.org/licenses/Saxpath.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Saxpath.json",
-      "referenceNumber": 421,
+      "referenceNumber": 15,
       "name": "Saxpath License",
       "licenseId": "Saxpath",
       "seeAlso": [
@@ -6902,7 +7381,7 @@
       "reference": "https://spdx.org/licenses/SCEA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SCEA.json",
-      "referenceNumber": 343,
+      "referenceNumber": 519,
       "name": "SCEA Shared Source License",
       "licenseId": "SCEA",
       "seeAlso": [
@@ -6914,7 +7393,7 @@
       "reference": "https://spdx.org/licenses/SchemeReport.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SchemeReport.json",
-      "referenceNumber": 435,
+      "referenceNumber": 655,
       "name": "Scheme Language Report License",
       "licenseId": "SchemeReport",
       "seeAlso": [],
@@ -6924,7 +7403,7 @@
       "reference": "https://spdx.org/licenses/Sendmail.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sendmail.json",
-      "referenceNumber": 473,
+      "referenceNumber": 146,
       "name": "Sendmail License",
       "licenseId": "Sendmail",
       "seeAlso": [
@@ -6937,7 +7416,7 @@
       "reference": "https://spdx.org/licenses/Sendmail-8.23.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sendmail-8.23.json",
-      "referenceNumber": 162,
+      "referenceNumber": 91,
       "name": "Sendmail License 8.23",
       "licenseId": "Sendmail-8.23",
       "seeAlso": [
@@ -6947,10 +7426,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/Sendmail-Open-Source-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Sendmail-Open-Source-1.1.json",
+      "referenceNumber": 526,
+      "name": "Sendmail Open Source License v1.1",
+      "licenseId": "Sendmail-Open-Source-1.1",
+      "seeAlso": [
+        "https://github.com/trusteddomainproject/OpenDMARC/blob/master/LICENSE.Sendmail"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/SGI-B-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGI-B-1.0.json",
-      "referenceNumber": 545,
+      "referenceNumber": 363,
       "name": "SGI Free Software License B v1.0",
       "licenseId": "SGI-B-1.0",
       "seeAlso": [
@@ -6962,7 +7453,7 @@
       "reference": "https://spdx.org/licenses/SGI-B-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGI-B-1.1.json",
-      "referenceNumber": 70,
+      "referenceNumber": 280,
       "name": "SGI Free Software License B v1.1",
       "licenseId": "SGI-B-1.1",
       "seeAlso": [
@@ -6974,7 +7465,7 @@
       "reference": "https://spdx.org/licenses/SGI-B-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGI-B-2.0.json",
-      "referenceNumber": 344,
+      "referenceNumber": 700,
       "name": "SGI Free Software License B v2.0",
       "licenseId": "SGI-B-2.0",
       "seeAlso": [
@@ -6987,7 +7478,7 @@
       "reference": "https://spdx.org/licenses/SGI-OpenGL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGI-OpenGL.json",
-      "referenceNumber": 534,
+      "referenceNumber": 409,
       "name": "SGI OpenGL License",
       "licenseId": "SGI-OpenGL",
       "seeAlso": [
@@ -6999,7 +7490,7 @@
       "reference": "https://spdx.org/licenses/SGP4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGP4.json",
-      "referenceNumber": 443,
+      "referenceNumber": 550,
       "name": "SGP4 Permission Notice",
       "licenseId": "SGP4",
       "seeAlso": [
@@ -7011,7 +7502,7 @@
       "reference": "https://spdx.org/licenses/SHL-0.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SHL-0.5.json",
-      "referenceNumber": 128,
+      "referenceNumber": 467,
       "name": "Solderpad Hardware License v0.5",
       "licenseId": "SHL-0.5",
       "seeAlso": [
@@ -7023,7 +7514,7 @@
       "reference": "https://spdx.org/licenses/SHL-0.51.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SHL-0.51.json",
-      "referenceNumber": 49,
+      "referenceNumber": 84,
       "name": "Solderpad Hardware License, Version 0.51",
       "licenseId": "SHL-0.51",
       "seeAlso": [
@@ -7035,7 +7526,7 @@
       "reference": "https://spdx.org/licenses/SimPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SimPL-2.0.json",
-      "referenceNumber": 471,
+      "referenceNumber": 577,
       "name": "Simple Public License 2.0",
       "licenseId": "SimPL-2.0",
       "seeAlso": [
@@ -7047,7 +7538,7 @@
       "reference": "https://spdx.org/licenses/SISSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SISSL.json",
-      "referenceNumber": 335,
+      "referenceNumber": 600,
       "name": "Sun Industry Standards Source License v1.1",
       "licenseId": "SISSL",
       "seeAlso": [
@@ -7061,7 +7552,7 @@
       "reference": "https://spdx.org/licenses/SISSL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SISSL-1.2.json",
-      "referenceNumber": 592,
+      "referenceNumber": 158,
       "name": "Sun Industry Standards Source License v1.2",
       "licenseId": "SISSL-1.2",
       "seeAlso": [
@@ -7073,7 +7564,7 @@
       "reference": "https://spdx.org/licenses/SL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SL.json",
-      "referenceNumber": 626,
+      "referenceNumber": 41,
       "name": "SL License",
       "licenseId": "SL",
       "seeAlso": [
@@ -7085,7 +7576,7 @@
       "reference": "https://spdx.org/licenses/Sleepycat.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sleepycat.json",
-      "referenceNumber": 171,
+      "referenceNumber": 341,
       "name": "Sleepycat License",
       "licenseId": "Sleepycat",
       "seeAlso": [
@@ -7095,10 +7586,22 @@
       "isFsfLibre": true
     },
     {
+      "reference": "https://spdx.org/licenses/SMAIL-GPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SMAIL-GPL.json",
+      "referenceNumber": 646,
+      "name": "SMAIL General Public License",
+      "licenseId": "SMAIL-GPL",
+      "seeAlso": [
+        "https://sources.debian.org/copyright/license/debianutils/4.11.2/"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/SMLNJ.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SMLNJ.json",
-      "referenceNumber": 345,
+      "referenceNumber": 518,
       "name": "Standard ML of New Jersey License",
       "licenseId": "SMLNJ",
       "seeAlso": [
@@ -7111,7 +7614,7 @@
       "reference": "https://spdx.org/licenses/SMPPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SMPPL.json",
-      "referenceNumber": 398,
+      "referenceNumber": 497,
       "name": "Secure Messaging Protocol Public License",
       "licenseId": "SMPPL",
       "seeAlso": [
@@ -7123,7 +7626,7 @@
       "reference": "https://spdx.org/licenses/SNIA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SNIA.json",
-      "referenceNumber": 292,
+      "referenceNumber": 108,
       "name": "SNIA Public License 1.1",
       "licenseId": "SNIA",
       "seeAlso": [
@@ -7135,7 +7638,7 @@
       "reference": "https://spdx.org/licenses/snprintf.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/snprintf.json",
-      "referenceNumber": 387,
+      "referenceNumber": 347,
       "name": "snprintf License",
       "licenseId": "snprintf",
       "seeAlso": [
@@ -7144,10 +7647,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/SOFA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SOFA.json",
+      "referenceNumber": 21,
+      "name": "SOFA Software License",
+      "licenseId": "SOFA",
+      "seeAlso": [
+        "http://www.iausofa.org/tandc.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/softSurfer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/softSurfer.json",
-      "referenceNumber": 560,
+      "referenceNumber": 95,
       "name": "softSurfer License",
       "licenseId": "softSurfer",
       "seeAlso": [
@@ -7160,7 +7675,7 @@
       "reference": "https://spdx.org/licenses/Soundex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Soundex.json",
-      "referenceNumber": 79,
+      "referenceNumber": 417,
       "name": "Soundex License",
       "licenseId": "Soundex",
       "seeAlso": [
@@ -7172,7 +7687,7 @@
       "reference": "https://spdx.org/licenses/Spencer-86.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Spencer-86.json",
-      "referenceNumber": 25,
+      "referenceNumber": 314,
       "name": "Spencer License 86",
       "licenseId": "Spencer-86",
       "seeAlso": [
@@ -7184,7 +7699,7 @@
       "reference": "https://spdx.org/licenses/Spencer-94.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Spencer-94.json",
-      "referenceNumber": 333,
+      "referenceNumber": 197,
       "name": "Spencer License 94",
       "licenseId": "Spencer-94",
       "seeAlso": [
@@ -7197,7 +7712,7 @@
       "reference": "https://spdx.org/licenses/Spencer-99.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Spencer-99.json",
-      "referenceNumber": 350,
+      "referenceNumber": 627,
       "name": "Spencer License 99",
       "licenseId": "Spencer-99",
       "seeAlso": [
@@ -7209,7 +7724,7 @@
       "reference": "https://spdx.org/licenses/SPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SPL-1.0.json",
-      "referenceNumber": 561,
+      "referenceNumber": 633,
       "name": "Sun Public License v1.0",
       "licenseId": "SPL-1.0",
       "seeAlso": [
@@ -7222,7 +7737,7 @@
       "reference": "https://spdx.org/licenses/ssh-keyscan.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ssh-keyscan.json",
-      "referenceNumber": 87,
+      "referenceNumber": 206,
       "name": "ssh-keyscan License",
       "licenseId": "ssh-keyscan",
       "seeAlso": [
@@ -7234,7 +7749,7 @@
       "reference": "https://spdx.org/licenses/SSH-OpenSSH.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SSH-OpenSSH.json",
-      "referenceNumber": 571,
+      "referenceNumber": 516,
       "name": "SSH OpenSSH license",
       "licenseId": "SSH-OpenSSH",
       "seeAlso": [
@@ -7246,7 +7761,7 @@
       "reference": "https://spdx.org/licenses/SSH-short.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SSH-short.json",
-      "referenceNumber": 568,
+      "referenceNumber": 327,
       "name": "SSH short notice",
       "licenseId": "SSH-short",
       "seeAlso": [
@@ -7260,7 +7775,7 @@
       "reference": "https://spdx.org/licenses/SSLeay-standalone.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SSLeay-standalone.json",
-      "referenceNumber": 439,
+      "referenceNumber": 383,
       "name": "SSLeay License - standalone",
       "licenseId": "SSLeay-standalone",
       "seeAlso": [
@@ -7272,7 +7787,7 @@
       "reference": "https://spdx.org/licenses/SSPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SSPL-1.0.json",
-      "referenceNumber": 276,
+      "referenceNumber": 304,
       "name": "Server Side Public License, v 1",
       "licenseId": "SSPL-1.0",
       "seeAlso": [
@@ -7284,7 +7799,7 @@
       "reference": "https://spdx.org/licenses/StandardML-NJ.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/StandardML-NJ.json",
-      "referenceNumber": 646,
+      "referenceNumber": 629,
       "name": "Standard ML of New Jersey License",
       "licenseId": "StandardML-NJ",
       "seeAlso": [
@@ -7297,7 +7812,7 @@
       "reference": "https://spdx.org/licenses/SugarCRM-1.1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SugarCRM-1.1.3.json",
-      "referenceNumber": 209,
+      "referenceNumber": 19,
       "name": "SugarCRM Public License v1.1.3",
       "licenseId": "SugarCRM-1.1.3",
       "seeAlso": [
@@ -7306,10 +7821,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/SUL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SUL-1.0.json",
+      "referenceNumber": 188,
+      "name": "Sustainable Use License v1.0",
+      "licenseId": "SUL-1.0",
+      "seeAlso": [
+        "https://github.com/n8n-io/n8n/blob/master/LICENSE.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/Sun-PPP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sun-PPP.json",
-      "referenceNumber": 338,
+      "referenceNumber": 72,
       "name": "Sun PPP License",
       "licenseId": "Sun-PPP",
       "seeAlso": [
@@ -7321,7 +7848,7 @@
       "reference": "https://spdx.org/licenses/Sun-PPP-2000.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sun-PPP-2000.json",
-      "referenceNumber": 145,
+      "referenceNumber": 62,
       "name": "Sun PPP License (2000)",
       "licenseId": "Sun-PPP-2000",
       "seeAlso": [
@@ -7333,7 +7860,7 @@
       "reference": "https://spdx.org/licenses/SunPro.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SunPro.json",
-      "referenceNumber": 318,
+      "referenceNumber": 231,
       "name": "SunPro License",
       "licenseId": "SunPro",
       "seeAlso": [
@@ -7346,7 +7873,7 @@
       "reference": "https://spdx.org/licenses/SWL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SWL.json",
-      "referenceNumber": 262,
+      "referenceNumber": 336,
       "name": "Scheme Widget Library (SWL) Software License Agreement",
       "licenseId": "SWL",
       "seeAlso": [
@@ -7358,7 +7885,7 @@
       "reference": "https://spdx.org/licenses/swrule.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/swrule.json",
-      "referenceNumber": 370,
+      "referenceNumber": 244,
       "name": "swrule License",
       "licenseId": "swrule",
       "seeAlso": [
@@ -7370,7 +7897,7 @@
       "reference": "https://spdx.org/licenses/Symlinks.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Symlinks.json",
-      "referenceNumber": 65,
+      "referenceNumber": 410,
       "name": "Symlinks License",
       "licenseId": "Symlinks",
       "seeAlso": [
@@ -7382,7 +7909,7 @@
       "reference": "https://spdx.org/licenses/TAPR-OHL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TAPR-OHL-1.0.json",
-      "referenceNumber": 285,
+      "referenceNumber": 628,
       "name": "TAPR Open Hardware License v1.0",
       "licenseId": "TAPR-OHL-1.0",
       "seeAlso": [
@@ -7394,7 +7921,7 @@
       "reference": "https://spdx.org/licenses/TCL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TCL.json",
-      "referenceNumber": 158,
+      "referenceNumber": 68,
       "name": "TCL/TK License",
       "licenseId": "TCL",
       "seeAlso": [
@@ -7407,7 +7934,7 @@
       "reference": "https://spdx.org/licenses/TCP-wrappers.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TCP-wrappers.json",
-      "referenceNumber": 221,
+      "referenceNumber": 173,
       "name": "TCP Wrappers License",
       "licenseId": "TCP-wrappers",
       "seeAlso": [
@@ -7431,7 +7958,7 @@
       "reference": "https://spdx.org/licenses/TGPPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TGPPL-1.0.json",
-      "referenceNumber": 578,
+      "referenceNumber": 103,
       "name": "Transitive Grace Period Public Licence 1.0",
       "licenseId": "TGPPL-1.0",
       "seeAlso": [
@@ -7441,10 +7968,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/ThirdEye.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ThirdEye.json",
+      "referenceNumber": 152,
+      "name": "ThirdEye License",
+      "licenseId": "ThirdEye",
+      "seeAlso": [
+        "https://sourceware.org/cgit/binutils-gdb/tree/include/coff/symconst.h#n11"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/threeparttable.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/threeparttable.json",
-      "referenceNumber": 75,
+      "referenceNumber": 625,
       "name": "threeparttable License",
       "licenseId": "threeparttable",
       "seeAlso": [
@@ -7456,7 +7995,7 @@
       "reference": "https://spdx.org/licenses/TMate.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TMate.json",
-      "referenceNumber": 269,
+      "referenceNumber": 570,
       "name": "TMate Open Source License",
       "licenseId": "TMate",
       "seeAlso": [
@@ -7468,7 +8007,7 @@
       "reference": "https://spdx.org/licenses/TORQUE-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TORQUE-1.1.json",
-      "referenceNumber": 204,
+      "referenceNumber": 88,
       "name": "TORQUE v2.5+ Software License v1.1",
       "licenseId": "TORQUE-1.1",
       "seeAlso": [
@@ -7480,7 +8019,7 @@
       "reference": "https://spdx.org/licenses/TOSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TOSL.json",
-      "referenceNumber": 17,
+      "referenceNumber": 69,
       "name": "Trusster Open Source License",
       "licenseId": "TOSL",
       "seeAlso": [
@@ -7492,7 +8031,7 @@
       "reference": "https://spdx.org/licenses/TPDL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TPDL.json",
-      "referenceNumber": 519,
+      "referenceNumber": 406,
       "name": "Time::ParseDate License",
       "licenseId": "TPDL",
       "seeAlso": [
@@ -7504,7 +8043,7 @@
       "reference": "https://spdx.org/licenses/TPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TPL-1.0.json",
-      "referenceNumber": 360,
+      "referenceNumber": 37,
       "name": "THOR Public License 1.0",
       "licenseId": "TPL-1.0",
       "seeAlso": [
@@ -7513,10 +8052,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/TrustedQSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TrustedQSL.json",
+      "referenceNumber": 67,
+      "name": "TrustedQSL License",
+      "licenseId": "TrustedQSL",
+      "seeAlso": [
+        "https://sourceforge.net/p/trustedqsl/tqsl/ci/master/tree/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/TTWL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TTWL.json",
-      "referenceNumber": 159,
+      "referenceNumber": 412,
       "name": "Text-Tabs+Wrap License",
       "licenseId": "TTWL",
       "seeAlso": [
@@ -7529,7 +8080,7 @@
       "reference": "https://spdx.org/licenses/TTYP0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TTYP0.json",
-      "referenceNumber": 234,
+      "referenceNumber": 201,
       "name": "TTYP0 License",
       "licenseId": "TTYP0",
       "seeAlso": [
@@ -7541,7 +8092,7 @@
       "reference": "https://spdx.org/licenses/TU-Berlin-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TU-Berlin-1.0.json",
-      "referenceNumber": 99,
+      "referenceNumber": 180,
       "name": "Technische Universitaet Berlin License 1.0",
       "licenseId": "TU-Berlin-1.0",
       "seeAlso": [
@@ -7553,7 +8104,7 @@
       "reference": "https://spdx.org/licenses/TU-Berlin-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TU-Berlin-2.0.json",
-      "referenceNumber": 523,
+      "referenceNumber": 515,
       "name": "Technische Universitaet Berlin License 2.0",
       "licenseId": "TU-Berlin-2.0",
       "seeAlso": [
@@ -7562,10 +8113,23 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/Ubuntu-font-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Ubuntu-font-1.0.json",
+      "referenceNumber": 642,
+      "name": "Ubuntu Font Licence v1.0",
+      "licenseId": "Ubuntu-font-1.0",
+      "seeAlso": [
+        "https://ubuntu.com/legal/font-licence",
+        "https://assets.ubuntu.com/v1/81e5605d-ubuntu-font-licence-1.0.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/UCAR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UCAR.json",
-      "referenceNumber": 460,
+      "referenceNumber": 472,
       "name": "UCAR License",
       "licenseId": "UCAR",
       "seeAlso": [
@@ -7577,7 +8141,7 @@
       "reference": "https://spdx.org/licenses/UCL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UCL-1.0.json",
-      "referenceNumber": 426,
+      "referenceNumber": 378,
       "name": "Upstream Compatibility License v1.0",
       "licenseId": "UCL-1.0",
       "seeAlso": [
@@ -7589,7 +8153,7 @@
       "reference": "https://spdx.org/licenses/ulem.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ulem.json",
-      "referenceNumber": 459,
+      "referenceNumber": 212,
       "name": "ulem License",
       "licenseId": "ulem",
       "seeAlso": [
@@ -7601,7 +8165,7 @@
       "reference": "https://spdx.org/licenses/UMich-Merit.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UMich-Merit.json",
-      "referenceNumber": 341,
+      "referenceNumber": 346,
       "name": "Michigan/Merit Networks License",
       "licenseId": "UMich-Merit",
       "seeAlso": [
@@ -7613,7 +8177,7 @@
       "reference": "https://spdx.org/licenses/Unicode-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unicode-3.0.json",
-      "referenceNumber": 491,
+      "referenceNumber": 150,
       "name": "Unicode License v3",
       "licenseId": "Unicode-3.0",
       "seeAlso": [
@@ -7625,7 +8189,7 @@
       "reference": "https://spdx.org/licenses/Unicode-DFS-2015.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unicode-DFS-2015.json",
-      "referenceNumber": 442,
+      "referenceNumber": 120,
       "name": "Unicode License Agreement - Data Files and Software (2015)",
       "licenseId": "Unicode-DFS-2015",
       "seeAlso": [
@@ -7637,7 +8201,7 @@
       "reference": "https://spdx.org/licenses/Unicode-DFS-2016.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unicode-DFS-2016.json",
-      "referenceNumber": 194,
+      "referenceNumber": 680,
       "name": "Unicode License Agreement - Data Files and Software (2016)",
       "licenseId": "Unicode-DFS-2016",
       "seeAlso": [
@@ -7651,7 +8215,7 @@
       "reference": "https://spdx.org/licenses/Unicode-TOU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unicode-TOU.json",
-      "referenceNumber": 238,
+      "referenceNumber": 388,
       "name": "Unicode Terms of Use",
       "licenseId": "Unicode-TOU",
       "seeAlso": [
@@ -7664,7 +8228,7 @@
       "reference": "https://spdx.org/licenses/UnixCrypt.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UnixCrypt.json",
-      "referenceNumber": 146,
+      "referenceNumber": 86,
       "name": "UnixCrypt License",
       "licenseId": "UnixCrypt",
       "seeAlso": [
@@ -7678,7 +8242,7 @@
       "reference": "https://spdx.org/licenses/Unlicense.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unlicense.json",
-      "referenceNumber": 297,
+      "referenceNumber": 56,
       "name": "The Unlicense",
       "licenseId": "Unlicense",
       "seeAlso": [
@@ -7688,10 +8252,34 @@
       "isFsfLibre": true
     },
     {
+      "reference": "https://spdx.org/licenses/Unlicense-libtelnet.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Unlicense-libtelnet.json",
+      "referenceNumber": 174,
+      "name": "Unlicense - libtelnet variant",
+      "licenseId": "Unlicense-libtelnet",
+      "seeAlso": [
+        "https://github.com/seanmiddleditch/libtelnet/blob/develop/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Unlicense-libwhirlpool.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Unlicense-libwhirlpool.json",
+      "referenceNumber": 135,
+      "name": "Unlicense - libwhirlpool variant",
+      "licenseId": "Unlicense-libwhirlpool",
+      "seeAlso": [
+        "https://github.com/dfateyev/libwhirlpool/blob/master/README#L27"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/UPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UPL-1.0.json",
-      "referenceNumber": 4,
+      "referenceNumber": 433,
       "name": "Universal Permissive License v1.0",
       "licenseId": "UPL-1.0",
       "seeAlso": [
@@ -7704,7 +8292,7 @@
       "reference": "https://spdx.org/licenses/URT-RLE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/URT-RLE.json",
-      "referenceNumber": 563,
+      "referenceNumber": 659,
       "name": "Utah Raster Toolkit Run Length Encoded License",
       "licenseId": "URT-RLE",
       "seeAlso": [
@@ -7717,7 +8305,7 @@
       "reference": "https://spdx.org/licenses/Vim.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Vim.json",
-      "referenceNumber": 567,
+      "referenceNumber": 666,
       "name": "Vim License",
       "licenseId": "Vim",
       "seeAlso": [
@@ -7730,7 +8318,7 @@
       "reference": "https://spdx.org/licenses/VOSTROM.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/VOSTROM.json",
-      "referenceNumber": 454,
+      "referenceNumber": 98,
       "name": "VOSTROM Public License for Open Source",
       "licenseId": "VOSTROM",
       "seeAlso": [
@@ -7742,7 +8330,7 @@
       "reference": "https://spdx.org/licenses/VSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/VSL-1.0.json",
-      "referenceNumber": 309,
+      "referenceNumber": 207,
       "name": "Vovida Software License v1.0",
       "licenseId": "VSL-1.0",
       "seeAlso": [
@@ -7754,7 +8342,7 @@
       "reference": "https://spdx.org/licenses/W3C.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/W3C.json",
-      "referenceNumber": 570,
+      "referenceNumber": 405,
       "name": "W3C Software Notice and License (2002-12-31)",
       "licenseId": "W3C",
       "seeAlso": [
@@ -7768,7 +8356,7 @@
       "reference": "https://spdx.org/licenses/W3C-19980720.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/W3C-19980720.json",
-      "referenceNumber": 524,
+      "referenceNumber": 5,
       "name": "W3C Software Notice and License (1998-07-20)",
       "licenseId": "W3C-19980720",
       "seeAlso": [
@@ -7780,7 +8368,7 @@
       "reference": "https://spdx.org/licenses/W3C-20150513.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/W3C-20150513.json",
-      "referenceNumber": 300,
+      "referenceNumber": 602,
       "name": "W3C Software Notice and Document License (2015-05-13)",
       "licenseId": "W3C-20150513",
       "seeAlso": [
@@ -7788,13 +8376,13 @@
         "https://www.w3.org/copyright/software-license-2015/",
         "https://www.w3.org/copyright/software-license-2023/"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true
     },
     {
       "reference": "https://spdx.org/licenses/w3m.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/w3m.json",
-      "referenceNumber": 400,
+      "referenceNumber": 418,
       "name": "w3m License",
       "licenseId": "w3m",
       "seeAlso": [
@@ -7806,7 +8394,7 @@
       "reference": "https://spdx.org/licenses/Watcom-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Watcom-1.0.json",
-      "referenceNumber": 46,
+      "referenceNumber": 396,
       "name": "Sybase Open Watcom Public License 1.0",
       "licenseId": "Watcom-1.0",
       "seeAlso": [
@@ -7819,7 +8407,7 @@
       "reference": "https://spdx.org/licenses/Widget-Workshop.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Widget-Workshop.json",
-      "referenceNumber": 538,
+      "referenceNumber": 36,
       "name": "Widget Workshop License",
       "licenseId": "Widget-Workshop",
       "seeAlso": [
@@ -7828,10 +8416,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/WordNet.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/WordNet.json",
+      "referenceNumber": 81,
+      "name": "WordNet License",
+      "licenseId": "WordNet",
+      "seeAlso": [
+        "https://wordnet.princeton.edu/license-and-commercial-use"
+      ],
+      "isOsiApproved": true
+    },
+    {
       "reference": "https://spdx.org/licenses/Wsuipa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Wsuipa.json",
-      "referenceNumber": 559,
+      "referenceNumber": 440,
       "name": "Wsuipa License",
       "licenseId": "Wsuipa",
       "seeAlso": [
@@ -7840,10 +8440,23 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/WTFNMFPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/WTFNMFPL.json",
+      "referenceNumber": 54,
+      "name": "Do What The F*ck You Want To But It\u0027s Not My Fault Public License",
+      "licenseId": "WTFNMFPL",
+      "seeAlso": [
+        "https://github.com/adversary-org/wtfnmf/raw/refs/tags/1.0/COPYING.WTFNMFPL",
+        "https://github.com/adversary-org/wtfnmf/raw/3f2cd8235a64350a57a51b9739715edaea63ec1a/COPYING.WTFNMFPL-utf8"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/WTFPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/WTFPL.json",
-      "referenceNumber": 150,
+      "referenceNumber": 420,
       "name": "Do What The F*ck You Want To Public License",
       "licenseId": "WTFPL",
       "seeAlso": [
@@ -7854,10 +8467,22 @@
       "isFsfLibre": true
     },
     {
+      "reference": "https://spdx.org/licenses/wwl.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/wwl.json",
+      "referenceNumber": 575,
+      "name": "WWL License",
+      "licenseId": "wwl",
+      "seeAlso": [
+        "http://www.db.net/downloads/wwl+db-1.3.tgz"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/wxWindows.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/wxWindows.json",
-      "referenceNumber": 643,
+      "referenceNumber": 44,
       "name": "wxWindows Library License",
       "licenseId": "wxWindows",
       "seeAlso": [
@@ -7869,7 +8494,7 @@
       "reference": "https://spdx.org/licenses/X11.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/X11.json",
-      "referenceNumber": 583,
+      "referenceNumber": 667,
       "name": "X11 License",
       "licenseId": "X11",
       "seeAlso": [
@@ -7882,7 +8507,7 @@
       "reference": "https://spdx.org/licenses/X11-distribute-modifications-variant.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/X11-distribute-modifications-variant.json",
-      "referenceNumber": 556,
+      "referenceNumber": 549,
       "name": "X11 License Distribution Modification Variant",
       "licenseId": "X11-distribute-modifications-variant",
       "seeAlso": [
@@ -7891,10 +8516,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/X11-swapped.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/X11-swapped.json",
+      "referenceNumber": 399,
+      "name": "X11 swapped final paragraphs",
+      "licenseId": "X11-swapped",
+      "seeAlso": [
+        "https://github.com/fedeinthemix/chez-srfi/blob/master/srfi/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/Xdebug-1.03.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Xdebug-1.03.json",
-      "referenceNumber": 609,
+      "referenceNumber": 311,
       "name": "Xdebug License v 1.03",
       "licenseId": "Xdebug-1.03",
       "seeAlso": [
@@ -7906,7 +8543,7 @@
       "reference": "https://spdx.org/licenses/Xerox.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Xerox.json",
-      "referenceNumber": 432,
+      "referenceNumber": 240,
       "name": "Xerox License",
       "licenseId": "Xerox",
       "seeAlso": [
@@ -7918,7 +8555,7 @@
       "reference": "https://spdx.org/licenses/Xfig.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Xfig.json",
-      "referenceNumber": 415,
+      "referenceNumber": 340,
       "name": "Xfig License",
       "licenseId": "Xfig",
       "seeAlso": [
@@ -7932,7 +8569,7 @@
       "reference": "https://spdx.org/licenses/XFree86-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/XFree86-1.1.json",
-      "referenceNumber": 499,
+      "referenceNumber": 283,
       "name": "XFree86 License 1.1",
       "licenseId": "XFree86-1.1",
       "seeAlso": [
@@ -7945,7 +8582,7 @@
       "reference": "https://spdx.org/licenses/xinetd.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xinetd.json",
-      "referenceNumber": 66,
+      "referenceNumber": 241,
       "name": "xinetd License",
       "licenseId": "xinetd",
       "seeAlso": [
@@ -7958,7 +8595,7 @@
       "reference": "https://spdx.org/licenses/xkeyboard-config-Zinoviev.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xkeyboard-config-Zinoviev.json",
-      "referenceNumber": 44,
+      "referenceNumber": 111,
       "name": "xkeyboard-config Zinoviev License",
       "licenseId": "xkeyboard-config-Zinoviev",
       "seeAlso": [
@@ -7970,7 +8607,7 @@
       "reference": "https://spdx.org/licenses/xlock.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xlock.json",
-      "referenceNumber": 536,
+      "referenceNumber": 165,
       "name": "xlock License",
       "licenseId": "xlock",
       "seeAlso": [
@@ -7982,7 +8619,7 @@
       "reference": "https://spdx.org/licenses/Xnet.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Xnet.json",
-      "referenceNumber": 395,
+      "referenceNumber": 113,
       "name": "X.Net License",
       "licenseId": "Xnet",
       "seeAlso": [
@@ -7994,7 +8631,7 @@
       "reference": "https://spdx.org/licenses/xpp.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xpp.json",
-      "referenceNumber": 189,
+      "referenceNumber": 513,
       "name": "XPP License",
       "licenseId": "xpp",
       "seeAlso": [
@@ -8006,7 +8643,7 @@
       "reference": "https://spdx.org/licenses/XSkat.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/XSkat.json",
-      "referenceNumber": 622,
+      "referenceNumber": 619,
       "name": "XSkat License",
       "licenseId": "XSkat",
       "seeAlso": [
@@ -8018,7 +8655,7 @@
       "reference": "https://spdx.org/licenses/xzoom.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xzoom.json",
-      "referenceNumber": 218,
+      "referenceNumber": 449,
       "name": "xzoom License",
       "licenseId": "xzoom",
       "seeAlso": [
@@ -8030,7 +8667,7 @@
       "reference": "https://spdx.org/licenses/YPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/YPL-1.0.json",
-      "referenceNumber": 332,
+      "referenceNumber": 20,
       "name": "Yahoo! Public License v1.0",
       "licenseId": "YPL-1.0",
       "seeAlso": [
@@ -8042,7 +8679,7 @@
       "reference": "https://spdx.org/licenses/YPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/YPL-1.1.json",
-      "referenceNumber": 186,
+      "referenceNumber": 325,
       "name": "Yahoo! Public License v1.1",
       "licenseId": "YPL-1.1",
       "seeAlso": [
@@ -8055,7 +8692,7 @@
       "reference": "https://spdx.org/licenses/Zed.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zed.json",
-      "referenceNumber": 22,
+      "referenceNumber": 299,
       "name": "Zed License",
       "licenseId": "Zed",
       "seeAlso": [
@@ -8067,7 +8704,7 @@
       "reference": "https://spdx.org/licenses/Zeeff.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zeeff.json",
-      "referenceNumber": 37,
+      "referenceNumber": 82,
       "name": "Zeeff License",
       "licenseId": "Zeeff",
       "seeAlso": [
@@ -8079,7 +8716,7 @@
       "reference": "https://spdx.org/licenses/Zend-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zend-2.0.json",
-      "referenceNumber": 274,
+      "referenceNumber": 154,
       "name": "Zend License v2.0",
       "licenseId": "Zend-2.0",
       "seeAlso": [
@@ -8092,7 +8729,7 @@
       "reference": "https://spdx.org/licenses/Zimbra-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zimbra-1.3.json",
-      "referenceNumber": 100,
+      "referenceNumber": 187,
       "name": "Zimbra Public License v1.3",
       "licenseId": "Zimbra-1.3",
       "seeAlso": [
@@ -8105,7 +8742,7 @@
       "reference": "https://spdx.org/licenses/Zimbra-1.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zimbra-1.4.json",
-      "referenceNumber": 413,
+      "referenceNumber": 622,
       "name": "Zimbra Public License v1.4",
       "licenseId": "Zimbra-1.4",
       "seeAlso": [
@@ -8117,7 +8754,7 @@
       "reference": "https://spdx.org/licenses/Zlib.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zlib.json",
-      "referenceNumber": 112,
+      "referenceNumber": 55,
       "name": "zlib License",
       "licenseId": "Zlib",
       "seeAlso": [
@@ -8131,7 +8768,7 @@
       "reference": "https://spdx.org/licenses/zlib-acknowledgement.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/zlib-acknowledgement.json",
-      "referenceNumber": 425,
+      "referenceNumber": 297,
       "name": "zlib/libpng License with Acknowledgement",
       "licenseId": "zlib-acknowledgement",
       "seeAlso": [
@@ -8143,7 +8780,7 @@
       "reference": "https://spdx.org/licenses/ZPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ZPL-1.1.json",
-      "referenceNumber": 381,
+      "referenceNumber": 105,
       "name": "Zope Public License 1.1",
       "licenseId": "ZPL-1.1",
       "seeAlso": [
@@ -8155,7 +8792,7 @@
       "reference": "https://spdx.org/licenses/ZPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ZPL-2.0.json",
-      "referenceNumber": 627,
+      "referenceNumber": 437,
       "name": "Zope Public License 2.0",
       "licenseId": "ZPL-2.0",
       "seeAlso": [
@@ -8169,7 +8806,7 @@
       "reference": "https://spdx.org/licenses/ZPL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ZPL-2.1.json",
-      "referenceNumber": 438,
+      "referenceNumber": 83,
       "name": "Zope Public License 2.1",
       "licenseId": "ZPL-2.1",
       "seeAlso": [
@@ -8179,5 +8816,5 @@
       "isFsfLibre": true
     }
   ],
-  "releaseDate": "2024-05-10"
+  "releaseDate": "2025-08-20T00:00:00Z"
 }

--- a/conda_recipe_manager/licenses/spdx_utils.py
+++ b/conda_recipe_manager/licenses/spdx_utils.py
@@ -40,6 +40,10 @@ class SpdxUtils:
         self._license_matching_table: dict[str, str] = {}
         self._license_ids: set[str] = set()
         for license_data in self._raw_spdx_data["licenses"]:
+            # Filter-out deprecated licenses. Fixes #423.
+            if "isDeprecatedLicenseId" in license_data and license_data["isDeprecatedLicenseId"]:
+                continue
+
             license_id = license_data["licenseId"]
             license_name = license_data["name"]
             # SPDX IDs are unique and used for SPDX validation. Commonly recipes use variations on names or IDs, so we

--- a/conda_recipe_manager/licenses/spdx_utils.py
+++ b/conda_recipe_manager/licenses/spdx_utils.py
@@ -29,6 +29,27 @@ class SpdxUtils:
     Class that provides SPDX tooling from the SPDX license database file.
     """
 
+    # Custom patch table that attempts to correct common SPDX licensing mistakes that our other methodologies cannot
+    # handle. Maps: `MISTAKE` (all uppercase) -> `Corrected`
+    _LICENSE_MATCHING_PATCH_TBL: Final[dict[str, str]] = {
+        # This commonly used name is not close enough for `difflib` to recognize
+        'BSD 2-CLAUSE "SIMPLIFIED"': "BSD-2-Clause",
+        # Some R packages use "Unlimited". This is the mapping the team agreed to use in a Slack thread.
+        "UNLIMITED": "NOASSERTION",
+    }
+
+    # There are enough GPL license variants that maintaining all of them in the patch table would be painful.
+    # So we attempt to upgrade the older names to the newer by appending the appropriate suffix. NOTE: These strings
+    # are capitalized in order to match the "normalized" look-up table.
+    _GPL_ONLY_SUFFIXES: Final[list[str]] = [
+        "-ONLY",
+        ".0-ONLY",  # In case someone has written something like "GPL 3"
+    ]
+    _GPL_OR_LATER_SUFFIXES: Final[list[str]] = [
+        "-OR-LATER",
+        ".0-OR-LATER",
+    ]
+
     def __init__(self) -> None:
         """
         Constructs a SPDX utility instance. Reads data from the JSON file provided by the module.
@@ -40,40 +61,20 @@ class SpdxUtils:
 
         # Generate a few look-up tables for license matching once during initialization for faster future look-ups.
         self._license_matching_table: dict[str, str] = {}
-        self._license_ids: set[str] = set()
+        # Matches case-insensitive license IDs to the expected ID
+        self._license_ids_normalized_table: dict[str, str] = {}
         for license_data in self._raw_spdx_data["licenses"]:
             # Filter-out deprecated licenses. Fixes #423.
             if "isDeprecatedLicenseId" in license_data and license_data["isDeprecatedLicenseId"]:
                 continue
 
-            license_id = license_data["licenseId"]
-            license_name = license_data["name"]
+            license_id = license_data["licenseId"].strip()
+            license_name = license_data["name"].strip()
             # SPDX IDs are unique and used for SPDX validation. Commonly recipes use variations on names or IDs, so we
             # want to map both options to the same ID.
             self._license_matching_table[license_name] = license_id
             self._license_matching_table[license_id] = license_id
-            # TODO make this a normalized -> actual name table. Add mixed-case tests for GPL.
-            self._license_ids.add(license_id)
-
-        # Custom patch table that attempts to correct common SPDX licensing mistakes that our other methodologies cannot
-        # handle. Maps: `MISTAKE` (all uppercase) -> `Corrected`
-        self._license_matching_patch_tbl: Final[dict[str, str]] = {
-            # This commonly used name is not close enough for `difflib` to recognize
-            'BSD 2-CLAUSE "SIMPLIFIED"': "BSD-2-Clause",
-            # Some R packages use "Unlimited". This is the mapping the team agreed to use in a Slack thread.
-            "UNLIMITED": "NOASSERTION",
-        }
-
-        # There are enough GPL license variants that maintaining all of them in the patch table would be painful.
-        # So we attempt to upgrade the older names to the newer by appending the appropriate suffix.
-        self._gpl_only_suffixes: Final[list[str]] = [
-            "-only",
-            ".0-only",  # In case someone has written something like "GPL 3"
-        ]
-        self._gpl_or_later_suffixes: Final[list[str]] = [
-            "-or-later",
-            ".0-or-later",
-        ]
+            self._license_ids_normalized_table[license_id.upper()] = license_id
 
     def _match_gpl_license(self, sanitized_license: str) -> Optional[str]:
         """
@@ -86,14 +87,14 @@ class SpdxUtils:
         # Determine if we are in the "-or-later" case.
         # NOTE: In the future, we could look into making a network call to match old to new(?)
         target_suffixes: Final = (
-            self._gpl_or_later_suffixes if sanitized_license[-1] == "+" else self._gpl_only_suffixes
+            SpdxUtils._GPL_OR_LATER_SUFFIXES if sanitized_license[-1] == "+" else SpdxUtils._GPL_ONLY_SUFFIXES
         )
         sanitized_gpl_license: Final = sanitized_license[:-1] if sanitized_license[-1] == "+" else sanitized_license
 
         for suffix in target_suffixes:
             license_with_suffix = f"{sanitized_gpl_license}{suffix}"
-            if license_with_suffix in self._license_ids:
-                return license_with_suffix
+            if license_with_suffix in self._license_ids_normalized_table:
+                return self._license_ids_normalized_table[license_with_suffix]
 
         return None
 
@@ -110,18 +111,16 @@ class SpdxUtils:
         :param license_field: License string provided by the recipe to match
         :returns: The closest matching SPDX identifier, if found
         """
-        sanitized_license: Final = license_field.strip()
-        # Used when finding EXACT matches in the the patch table.
-        sanitized_license_upper: Final = sanitized_license.upper()
+        sanitized_license: Final = license_field.strip().upper()
 
         # Short-circuit on perfect matches
-        if sanitized_license in self._license_ids:
-            return sanitized_license
+        if sanitized_license in self._license_ids_normalized_table:
+            return self._license_ids_normalized_table[sanitized_license]
 
         # Correct known commonly used licenses that can't be handled by `difflib`. NOTE: This table normalizes around
         # upper-cased keys.
-        if sanitized_license_upper in self._license_matching_patch_tbl:
-            return self._license_matching_patch_tbl[sanitized_license_upper]
+        if sanitized_license in SpdxUtils._LICENSE_MATCHING_PATCH_TBL:
+            return SpdxUtils._LICENSE_MATCHING_PATCH_TBL[sanitized_license]
 
         # Short-circuit on known deprecation upgrade paths.
         if (gpl_match := self._match_gpl_license(sanitized_license)) is not None:

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -41,6 +41,7 @@ class RecipeParserConvert(RecipeParserDeps):
         # is no development cost in utilizing tools we already must maintain.
         self._v1_recipe: RecipeParserDeps = RecipeParserDeps(self.render())
 
+        # TODO make _spdx_utils static!
         self._spdx_utils = SpdxUtils()
         self._msg_tbl = MessageTable()
 

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -28,6 +28,10 @@ class RecipeParserConvert(RecipeParserDeps):
     This was originally part of the RecipeParserDeps class but was broken-out for easier maintenance.
     """
 
+    # "Static", one-time initialization of the the SPDX utility class. As this module is "read-only", we only need one
+    # instance allocated for all converter-parsers that are initialized.
+    _SPDX_UTILS: Final = SpdxUtils()
+
     def __init__(self, content: str):
         """
         Constructs a convertible recipe object. This extension of the parser class keeps a modified copy of the original
@@ -41,8 +45,6 @@ class RecipeParserConvert(RecipeParserDeps):
         # is no development cost in utilizing tools we already must maintain.
         self._v1_recipe: RecipeParserDeps = RecipeParserDeps(self.render())
 
-        # TODO make _spdx_utils static!
-        self._spdx_utils = SpdxUtils()
         self._msg_tbl = MessageTable()
 
     ## Patch utility functions ##
@@ -618,7 +620,9 @@ class RecipeParserConvert(RecipeParserDeps):
             self._msg_tbl.add_message(MessageCategory.WARNING, f"No `license` provided in `{about_path}`")
             return
 
-        corrected_license: Final[Optional[str]] = self._spdx_utils.find_closest_license_match(old_license)
+        corrected_license: Final[Optional[str]] = RecipeParserConvert._SPDX_UTILS.find_closest_license_match(
+            old_license
+        )
 
         if corrected_license is None:
             self._msg_tbl.add_message(MessageCategory.WARNING, f"Could not patch unrecognized license: `{old_license}`")

--- a/tests/license/test_spdx_utils.py
+++ b/tests/license/test_spdx_utils.py
@@ -22,15 +22,29 @@ from conda_recipe_manager.licenses.spdx_utils import SpdxUtils
         ("BSD 3-Clause", "BSD-3-Clause"),
         ("BSD_3_Clause", "BSD-3-Clause"),
         #### GPL ####
-        ("GPL-2", "GPL-2.0"),
-        ("GPL-3", "GPL-3.0"),
+        ("GPL-2.0-only", "GPL-2.0-only"),
+        ("GPL-3.0-only", "GPL-3.0-only"),
+        ("AGPL-1.0-only", "AGPL-1.0-only"),
+        ("LGPL-2.1-or-later", "LGPL-2.1-or-later"),
+        # See Issue #423 for more details about converting to use `-only`/`-or-later` names.
+        ("GPL-2", "GPL-2.0-only"),
+        ("GPL-3", "GPL-3.0-only"),
+        ("GPL-2.0", "GPL-2.0-only"),
+        ("GPL-3.0", "GPL-3.0-only"),
+        ("AGPL-1.0", "AGPL-1.0-only"),
+        ("AGPL-1", "AGPL-1.0-only"),
+        ("GPL-1.0+", "GPL-1.0-or-later"),
+        ("GPL-1+", "GPL-1.0-or-later"),
+        ("LGPL-2.1+", "LGPL-2.1-or-later"),
+        ("LGPL-2.1", "LGPL-2.1-only"),
         #### Special cases that are "manually" handled outside of `difflib` ####
         ('BSD 2-Clause "SIMPLIFIED"', "BSD-2-Clause"),
     ],
 )
-def test_find_closest_license_match_common_misuse(license_field: str, expected: str) -> None:
+def test_find_closest_license_match_common_issues(license_field: str, expected: str) -> None:
     """
-    Validates license matching with commonly used incorrect license names
+    Validates license matching with commonly used "incorrect" license names and attempts to upgrade deprecated license
+    names.
     """
     # TODO fixture
     spdx_utils = SpdxUtils()
@@ -41,7 +55,9 @@ def test_find_closest_license_match_common_misuse(license_field: str, expected: 
     "license_field",
     [
         "foobar",
-        "batman",
+        # Batman no longer works because `Gutmann` is a legitimate license with a close-enough name. So we're stuck with
+        # the sidekick, I guess.
+        "robin",
         "fadsjkl;adshbfjkasd",
     ],
 )

--- a/tests/license/test_spdx_utils.py
+++ b/tests/license/test_spdx_utils.py
@@ -16,6 +16,7 @@ from conda_recipe_manager.licenses.spdx_utils import SpdxUtils
         ("Apache License 1.0", "Apache-1.0"),
         ("Apache License 1.1", "Apache-1.1"),
         ("Apache License 2.0", "Apache-2.0"),
+        ("APaCHE LIcenSe 2.0", "Apache-2.0"),
         #### BSD ####
         ("BSD 1-Clause", "BSD-1-Clause"),
         ("BSD_2_Clause", "BSD-2-Clause"),
@@ -39,6 +40,10 @@ from conda_recipe_manager.licenses.spdx_utils import SpdxUtils
         ("LGPL-2.1", "LGPL-2.1-only"),
         #### Special cases that are "manually" handled outside of `difflib` ####
         ('BSD 2-Clause "SIMPLIFIED"', "BSD-2-Clause"),
+        #### Matches that should work if casing is normalized ####
+        ("gPl-2", "GPL-2.0-only"),
+        ("gpL-2.0", "GPL-2.0-only"),
+        ("LgPl-2.1+", "LGPL-2.1-or-later"),
     ],
 )
 def test_find_closest_license_match_common_issues(license_field: str, expected: str) -> None:


### PR DESCRIPTION
Fixes #423 by:
- Updating the license file database
- The SPDX matching algorithm now filters deprecated names
- Adds specific logic to match GPL license with their new `-only`/`-or-later` designations

Also:
- Makes some performance improvements
- Makes some improvements around handling mixed-cased strings that would otherwise match the custom correction algorithms.