### PR TITLE
Handle empty dependency section in add_dependency()

### DIFF
--- a/conda_recipe_manager/parser/recipe_parser_deps.py
+++ b/conda_recipe_manager/parser/recipe_parser_deps.py
@@ -21,6 +21,7 @@ from conda_recipe_manager.types import JsonType
 # Dependency validation constants
 _SINGLE_OUTPUT_LEN: Final[int] = 4
 _MULTI_OUTPUT_LEN: Final[int] = 6
+_DEPENDENCY_SECTION_PARENT: Final[set[str]] = {"requirements", "test"}
 
 
 class RecipeParserDeps(RecipeParser, RecipeReaderDeps):
@@ -49,7 +50,7 @@ class RecipeParserDeps(RecipeParser, RecipeReaderDeps):
         if len_path == _SINGLE_OUTPUT_LEN:
             return (
                 not bool(path[0])
-                and path[1] in {"requirements", "test"}
+                and path[1] in _DEPENDENCY_SECTION_PARENT
                 and str_to_dependency_section(path[2]) is not None
                 and path[3].isdigit()
             )
@@ -59,7 +60,7 @@ class RecipeParserDeps(RecipeParser, RecipeReaderDeps):
             not bool(path[0])
             and path[1] == "outputs"
             and path[2].isdigit()
-            and path[3] in {"requirements", "test"}
+            and path[3] in _DEPENDENCY_SECTION_PARENT
             and str_to_dependency_section(path[4]) is not None
             and path[5].isdigit()
         )

--- a/conda_recipe_manager/parser/recipe_parser_deps.py
+++ b/conda_recipe_manager/parser/recipe_parser_deps.py
@@ -169,9 +169,10 @@ class RecipeParserDeps(RecipeParser, RecipeReaderDeps):
         patch_path = RecipeParserDeps._init_patch_path(dep, dep_mode, base_path, is_new_section)
 
         # TODO: Add a "get dependencies at path" function to `RecipeReaderDeps`
-        cur_deps: Final[list[Optional[str]]] = cast(
-            list[Optional[str]], self.get_value(base_path, sub_vars=True, default=[])
-        )
+        opt_cur_deps = self.get_value(base_path, sub_vars=True, default=[])
+        # Handle empty section case
+        opt_cur_deps = [] if opt_cur_deps is None else opt_cur_deps
+        cur_deps: Final[list[Optional[str]]] = cast(list[Optional[str]], opt_cur_deps)
 
         # Check for duplicate dependencies, if applicable.
         if dep_mode not in {DependencyConflictMode.USE_BOTH, DependencyConflictMode.EXACT_POSITION}:

--- a/conda_recipe_manager/parser/recipe_parser_deps.py
+++ b/conda_recipe_manager/parser/recipe_parser_deps.py
@@ -49,7 +49,7 @@ class RecipeParserDeps(RecipeParser, RecipeReaderDeps):
         if len_path == _SINGLE_OUTPUT_LEN:
             return (
                 not bool(path[0])
-                and path[1] == "requirements"
+                and path[1] in {"requirements", "test"}
                 and str_to_dependency_section(path[2]) is not None
                 and path[3].isdigit()
             )
@@ -59,7 +59,7 @@ class RecipeParserDeps(RecipeParser, RecipeReaderDeps):
             not bool(path[0])
             and path[1] == "outputs"
             and path[2].isdigit()
-            and path[3] == "requirements"
+            and path[3] in {"requirements", "test"}
             and str_to_dependency_section(path[4]) is not None
             and path[5].isdigit()
         )

--- a/tests/parser/test_recipe_parser_deps.py
+++ b/tests/parser/test_recipe_parser_deps.py
@@ -349,7 +349,7 @@ from tests.file_loading import load_recipe
             "/requirements/host/8",
             "[unix]",
         ),
-        # Regression: Add a dependency to an empty section
+        # Regression: Add a dependency to an empty section. See Issue #425 for more details.
         (
             "empty_dependency_section.yaml",
             Dependency(

--- a/tests/parser/test_recipe_parser_deps.py
+++ b/tests/parser/test_recipe_parser_deps.py
@@ -349,6 +349,24 @@ from tests.file_loading import load_recipe
             "/requirements/host/8",
             "[unix]",
         ),
+        # Regression: Add a dependency to an empty section
+        (
+            "empty_dependency_section.yaml",
+            Dependency(
+                "test-empty-dependency-section",
+                "/requirements/host/0",
+                DependencySection.HOST,
+                MatchSpec("python"),
+                None,
+            ),
+            DependencyConflictMode.REPLACE,
+            SelectorConflictMode.REPLACE,
+            True,
+            "/requirements/host",
+            ["python"],
+            "/requirements/host/0",
+            None,
+        ),
         # TODO Add V1 support
     ],
 )

--- a/tests/test_aux_files/empty_dependency_section.yaml
+++ b/tests/test_aux_files/empty_dependency_section.yaml
@@ -1,0 +1,9 @@
+package:
+  name: test-empty-dependency-section
+  version: 1.0
+
+build:
+  number: 0
+  
+requirements:
+  host:

--- a/tests/test_aux_files/empty_dependency_section.yaml
+++ b/tests/test_aux_files/empty_dependency_section.yaml
@@ -4,6 +4,6 @@ package:
 
 build:
   number: 0
-  
+
 requirements:
   host:


### PR DESCRIPTION
### Description

- A `get_value()` call may return `None` when a default value is supplied, if the path exists and is simply an empty key.
This case was encountered when attempting to call `add_dependency()` to add a dependency to an empty (host or run) section.
- `_is_valid_dependency_path()` was not inclusive of test dependency paths.

### Solution

- Handle the edge-case before proceeding.
- Amend `_is_valid_dependency_path()` logic.