### PR TITLE
Add an include_test_dependencies optional arg to RecipeReaderDeps.get_all_dependencies()

### DIFF
--- a/conda_recipe_manager/parser/dependency.py
+++ b/conda_recipe_manager/parser/dependency.py
@@ -28,7 +28,6 @@ class DependencySection(Enum):
     # NOTE:
     #   - Test dependencies are not found under the `requirements/` section, they are found under the testing section.
     #   - There are major changes to the testing section in V1.
-    # TODO TEST not covered in get_all_dependencies()
     TESTS = auto()
 
 

--- a/conda_recipe_manager/parser/recipe_reader_deps.py
+++ b/conda_recipe_manager/parser/recipe_reader_deps.py
@@ -152,7 +152,7 @@ class RecipeReaderDeps(RecipeReader):
             dep = RecipeReaderDeps._sanitize_dep(dep)
             if dep is None:
                 continue
-
+            # TODO add V1 support, the test section is different.
             dep_path = RecipeReader.append_to_path(path, f"/test/requires/{i}")
             dep_map[package].append(
                 Dependency(

--- a/conda_recipe_manager/parser/recipe_reader_deps.py
+++ b/conda_recipe_manager/parser/recipe_reader_deps.py
@@ -168,6 +168,8 @@ class RecipeReaderDeps(RecipeReader):
         """
         Get a parsed representation of all the dependencies found in the recipe.
 
+        :param include_test_dependencies: (Optional) If True, include test dependencies.
+            Defaults to False, which will exclude test dependencies, for backwards compatibility.
         :raises KeyError: If a package in the recipe does not have a name
         :raises ValueError: If a recipe contains a package with duplicate names
         :returns: A structured representation of the dependencies.

--- a/conda_recipe_manager/parser/recipe_reader_deps.py
+++ b/conda_recipe_manager/parser/recipe_reader_deps.py
@@ -10,6 +10,7 @@ from conda_recipe_manager.parser._types import ROOT_NODE_VALUE
 from conda_recipe_manager.parser.dependency import (
     Dependency,
     DependencyMap,
+    DependencySection,
     dependency_data_from_str,
     str_to_dependency_section,
 )
@@ -102,7 +103,68 @@ class RecipeReaderDeps(RecipeReader):
             package_tbl[name] = path
         return package_tbl
 
-    def get_all_dependencies(self) -> DependencyMap:
+    def _extract_requirements(
+        self, requirements: dict[str, list[Optional[str]]], dep_map: DependencyMap, path: str, package: str
+    ) -> None:
+        """
+        Extracts dependencies from a requirements section.
+
+        :param requirements: The requirements section to extract dependencies from.
+        :param dep_map: The dependency map to add the dependencies to.
+        :param path: The path to the requirements section.
+        :param package: The package to add the dependencies to.
+        """
+        for section_str, deps in requirements.items():
+            section = str_to_dependency_section(section_str)
+            # Unrecognized sections will be skipped as "junk" data
+            if section is None or deps is None:
+                continue
+
+            for i, dep in enumerate(deps):
+                dep = RecipeReaderDeps._sanitize_dep(dep)
+                if dep is None:
+                    continue
+
+                # NOTE: `get_dependency_paths()` uses the same approach for calculating dependency paths.
+                dep_path = RecipeReader.append_to_path(path, f"/requirements/{section_str}/{i}")
+                dep_map[package].append(
+                    Dependency(
+                        required_by=package,
+                        path=dep_path,
+                        type=section,
+                        data=dependency_data_from_str(dep),
+                        selector=self._fetch_optional_selector(dep_path),
+                    )
+                )
+
+    def _extract_test_requirements(
+        self, test_requirements: list[Optional[str]], dep_map: DependencyMap, path: str, package: str
+    ) -> None:
+        """
+        Extracts test dependencies from a test requirements section.
+
+        :param test_requirements: The test requirements section to extract dependencies from.
+        :param dep_map: The dependency map to add the dependencies to.
+        :param path: The path to the test requirements section.
+        :param package: The package to add the dependencies to.
+        """
+        for i, dep in enumerate(test_requirements):
+            dep = RecipeReaderDeps._sanitize_dep(dep)
+            if dep is None:
+                continue
+
+            dep_path = RecipeReader.append_to_path(path, f"/test/requires/{i}")
+            dep_map[package].append(
+                Dependency(
+                    required_by=package,
+                    path=dep_path,
+                    type=DependencySection.TESTS,
+                    data=dependency_data_from_str(dep),
+                    selector=self._fetch_optional_selector(dep_path),
+                )
+            )
+
+    def get_all_dependencies(self, include_test_dependencies: bool = False) -> DependencyMap:
         """
         Get a parsed representation of all the dependencies found in the recipe.
 
@@ -119,36 +181,28 @@ class RecipeReaderDeps(RecipeReader):
             if path == ROOT_NODE_VALUE:
                 root_package = package
 
+            # Requirements
             requirements = cast(
                 Optional[str | dict[str, list[Optional[str]]]],
                 self.get_value(RecipeReader.append_to_path(path, "/requirements"), default={}, sub_vars=True),
             )
             # Skip over empty/malformed requirements sections
-            if requirements is None or isinstance(requirements, str):
+            if requirements is not None and not isinstance(requirements, str):
+                dep_map[package] = []
+                self._extract_requirements(requirements, dep_map, path, package)
+
+            # Test requirements
+            if not include_test_dependencies:
                 continue
-            dep_map[package] = []
-            for section_str, deps in requirements.items():
-                section = str_to_dependency_section(section_str)
-                # Unrecognized sections will be skipped as "junk" data
-                if section is None or deps is None:
-                    continue
-
-                for i, dep in enumerate(deps):
-                    dep = RecipeReaderDeps._sanitize_dep(dep)
-                    if dep is None:
-                        continue
-
-                    # NOTE: `get_dependency_paths()` uses the same approach for calculating dependency paths.
-                    dep_path = RecipeReader.append_to_path(path, f"/requirements/{section_str}/{i}")
-                    dep_map[package].append(
-                        Dependency(
-                            required_by=package,
-                            path=dep_path,
-                            type=section,
-                            data=dependency_data_from_str(dep),
-                            selector=self._fetch_optional_selector(dep_path),
-                        )
-                    )
+            test_requirements = cast(
+                Optional[list[Optional[str]]],
+                self.get_value(RecipeReader.append_to_path(path, "/test/requires"), default=[], sub_vars=True),
+            )
+            # Skip over empty/malformed test requirements sections
+            if test_requirements is not None and isinstance(test_requirements, list):
+                if package not in dep_map:
+                    dep_map[package] = []
+                self._extract_test_requirements(test_requirements, dep_map, path, package)
 
         # Apply top-level dependencies to multi-output recipe packages
         RecipeReaderDeps._add_top_level_dependencies(root_package, dep_map)

--- a/tests/parser/test_recipe_reader_deps.py
+++ b/tests/parser/test_recipe_reader_deps.py
@@ -56,7 +56,7 @@ def test_get_package_names_to_path(file: str, expected: dict[str, str]) -> None:
 
 
 @pytest.mark.parametrize(
-    "file,expected",
+    "file,expected,include_test_dependencies",
     [
         (
             "types-toml.yaml",
@@ -71,6 +71,7 @@ def test_get_package_names_to_path(file: str, expected: dict[str, str]) -> None:
                     Dependency("types-toml", "/requirements/run/0", DependencySection.RUN, MatchSpec("python"), None),
                 ]
             },
+            False,
         ),
         (
             "v1_format/v1_types-toml.yaml",
@@ -85,6 +86,7 @@ def test_get_package_names_to_path(file: str, expected: dict[str, str]) -> None:
                     Dependency("types-toml", "/requirements/run/0", DependencySection.RUN, MatchSpec("python"), None),
                 ]
             },
+            False,
         ),
         # simple-recipe.yaml tests that unrecognized requirements fields are ignored
         (
@@ -108,6 +110,7 @@ def test_get_package_names_to_path(file: str, expected: dict[str, str]) -> None:
                     Dependency("types-toml", "/requirements/run/0", DependencySection.RUN, MatchSpec("python"), None),
                 ]
             },
+            False,
         ),
         (
             "boto.yaml",
@@ -117,6 +120,7 @@ def test_get_package_names_to_path(file: str, expected: dict[str, str]) -> None:
                     Dependency("boto", "/requirements/run/0", DependencySection.RUN, MatchSpec("python"), None),
                 ]
             },
+            False,
         ),
         (
             "v1_format/v1_boto.yaml",
@@ -126,6 +130,7 @@ def test_get_package_names_to_path(file: str, expected: dict[str, str]) -> None:
                     Dependency("boto", "/requirements/run/0", DependencySection.RUN, MatchSpec("python"), None),
                 ]
             },
+            False,
         ),
         # TODO Future: Add V1 variant of this test when V1 selector support is added.
         (
@@ -264,6 +269,7 @@ def test_get_package_names_to_path(file: str, expected: dict[str, str]) -> None:
                     ),
                 ],
             },
+            False,
         ),
         # Regression Test: The parser previously crashed when trying to substitute `{{ compiler('c' ) }}`
         (
@@ -514,10 +520,70 @@ def test_get_package_names_to_path(file: str, expected: dict[str, str]) -> None:
                     ),
                 ],
             },
+            False,
+        ),
+        # Test dependencies
+        (
+            "h5py.yaml",
+            {
+                "h5py": [
+                    # Build dependencies
+                    Dependency(
+                        "h5py",
+                        "/requirements/build/0",
+                        DependencySection.BUILD,
+                        DependencyVariable('{{ compiler("c") }}'),
+                        None,
+                    ),
+                    # Host dependencies
+                    Dependency("h5py", "/requirements/host/0", DependencySection.HOST, MatchSpec("python"), None),
+                    Dependency(
+                        "h5py",
+                        "/requirements/host/1",
+                        DependencySection.HOST,
+                        MatchSpec("cython[version='>=0.29.15,<4']"),
+                        None,
+                    ),
+                    Dependency(
+                        "h5py",
+                        "/requirements/host/2",
+                        DependencySection.HOST,
+                        MatchSpec("hdf5[version='1.12.1']"),
+                        None,
+                    ),
+                    Dependency(
+                        "h5py",
+                        "/requirements/host/3",
+                        DependencySection.HOST,
+                        DependencyVariable("numpy {{ numpy }}"),
+                        None,
+                    ),
+                    Dependency("h5py", "/requirements/host/4", DependencySection.HOST, MatchSpec("pip"), None),
+                    Dependency("h5py", "/requirements/host/5", DependencySection.HOST, MatchSpec("pkgconfig"), None),
+                    Dependency("h5py", "/requirements/host/6", DependencySection.HOST, MatchSpec("setuptools"), None),
+                    Dependency("h5py", "/requirements/host/7", DependencySection.HOST, MatchSpec("wheel"), None),
+                    # Run dependencies
+                    Dependency("h5py", "/requirements/run/0", DependencySection.RUN, MatchSpec("python"), None),
+                    Dependency("h5py", "/requirements/run/1", DependencySection.RUN, MatchSpec("hdf5"), None),
+                    Dependency(
+                        "h5py",
+                        "/requirements/run/2",
+                        DependencySection.RUN,
+                        DependencyVariable("{{ pin_compatible('numpy') }}"),
+                        None,
+                    ),
+                    # Test dependencies
+                    Dependency("h5py", "/test/requires/0", DependencySection.TESTS, MatchSpec("pip"), None),
+                    Dependency("h5py", "/test/requires/1", DependencySection.TESTS, MatchSpec("pytest"), None),
+                    Dependency("h5py", "/test/requires/2", DependencySection.TESTS, MatchSpec("pytest-mpi"), None),
+                    Dependency("h5py", "/test/requires/3", DependencySection.TESTS, MatchSpec("curl"), None),
+                ],
+            },
+            True,
         ),
     ],
 )
-def test_get_all_dependencies(file: str, expected: DependencyMap) -> None:
+def test_get_all_dependencies(file: str, expected: DependencyMap, include_test_dependencies: bool) -> None:
     """
     Validates generating all the dependency meta data associated with a recipe file.
 
@@ -525,4 +591,4 @@ def test_get_all_dependencies(file: str, expected: DependencyMap) -> None:
     :param expected: Expected output
     """
     parser = load_recipe(file, RecipeReaderDeps)
-    assert parser.get_all_dependencies() == expected
+    assert parser.get_all_dependencies(include_test_dependencies=include_test_dependencies) == expected

--- a/tests/parser/test_recipe_reader_deps.py
+++ b/tests/parser/test_recipe_reader_deps.py
@@ -581,6 +581,55 @@ def test_get_package_names_to_path(file: str, expected: dict[str, str]) -> None:
             },
             True,
         ),
+        (
+            "rust.yaml",
+            {
+                "rust-suite": [],
+                "rust": [
+                    # Build dependencies
+                    Dependency(
+                        "rust",
+                        "/outputs/0/requirements/build/0",
+                        DependencySection.BUILD,
+                        DependencyVariable("{{ compiler('c') }}"),
+                        SelectorParser("[osx]", SchemaVersion.V0),
+                    ),
+                    Dependency(
+                        "rust",
+                        "/outputs/0/requirements/build/1",
+                        DependencySection.BUILD,
+                        MatchSpec("posix"),
+                        SelectorParser("[win]", SchemaVersion.V0),
+                    ),
+                    # Test dependencies
+                    Dependency(
+                        "rust",
+                        "/outputs/0/test/requires/0",
+                        DependencySection.TESTS,
+                        DependencyVariable("{{ compiler('c') }}"),
+                        None,
+                    ),
+                    Dependency(
+                        "rust",
+                        "/outputs/0/test/requires/1",
+                        DependencySection.TESTS,
+                        DependencyVariable("{{ compiler('cxx') }}"),
+                        None,
+                    ),
+                ],
+                "rust-gnu": [
+                    # Build dependencies
+                    Dependency(
+                        "rust-gnu",
+                        "/outputs/1/requirements/build/0",
+                        DependencySection.BUILD,
+                        MatchSpec("posix"),
+                        SelectorParser("[win]", SchemaVersion.V0),
+                    ),
+                ],
+            },
+            True,
+        ),
     ],
 )
 def test_get_all_dependencies(file: str, expected: DependencyMap, include_test_dependencies: bool) -> None:


### PR DESCRIPTION
### Description

This PR addresses #433, adding the ability to optionally request all dependencies including test dependencies from `get_all_dependencies()`.

Added functionality and testing for the single-output and multi-output recipe cases.
