### PR TITLE
Add workflow concurrency limits

### DIFF
--- a/.github/workflows/commit_checks.yaml
+++ b/.github/workflows/commit_checks.yaml
@@ -6,6 +6,10 @@ on:
 
 name: Commit Checks
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # NOTE: Tests also run via `pre-commit`
   pre-commit:

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -6,6 +6,10 @@ on:
 
 name: Integration Tests
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ## Integration tests ##
   integration-rattler:


### PR DESCRIPTION
### Description

Add PR-aware concurrency groups to the commit-check and integration-test workflows so new commits cancel obsolete runs for the same pull request. Pushes to other refs remain isolated.

Part of conda/infrastructure#706

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex
