### PR TITLE
Fixes rattler-build smoke test

### DIFF
--- a/tests/test_smoke_testing.py
+++ b/tests/test_smoke_testing.py
@@ -7,6 +7,9 @@ import pytest_socket  # type: ignore[import-untyped]
 import requests
 
 
+# pytest-socket@0.8.0+ marks any socket usage with a pytest warning. We must suppress this in order to pass the
+# smoke-test that ensures pytest-socket is working as intended.
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_validate_pysocket_plugin() -> None:
     """
     Smoke test that ensures that the `pysocket` plugin is working by running an unmocked HTTP GET request that should


### PR DESCRIPTION
- `pytest-socket` has made some changes in the latest version(s) available on conda-forge, breaking the rattler-build tests (but not the conda-build equivalent)
- This appears to be a change in the pytest reporting mechanism, which causes the smoke test that purposefully trips `pytest-socket` to fail (which ensures the plugin is working as intended).