### PR TITLE
fix: ensure jinja templates are not replaced when fixing ambiguous variables

### DIFF
--- a/conda_recipe_manager/parser/dependency.py
+++ b/conda_recipe_manager/parser/dependency.py
@@ -133,6 +133,11 @@ class DependencyVariable:
         # TODO normalize common JINJA functions for quote usage
         self.name = s.strip()
 
+    # This property allows the object to be used as a MatchSpec without type guards similarly to `name` above.
+    @property
+    def original_spec_str(self) -> str:
+        return self.name
+
     def __eq__(self, o: object) -> bool:
         """
         Checks to see if two objects are equivalent.

--- a/conda_recipe_manager/parser/dependency.py
+++ b/conda_recipe_manager/parser/dependency.py
@@ -133,9 +133,13 @@ class DependencyVariable:
         # TODO normalize common JINJA functions for quote usage
         self.name = s.strip()
 
-    # This property allows the object to be used as a MatchSpec without type guards similarly to `name` above.
     @property
     def original_spec_str(self) -> str:
+        """
+        Property that allows the object to be used as a `MatchSpec` without type guards similarly to `name` above.
+        
+        :returns: A string representing the original specification.
+        """
         return self.name
 
     def __eq__(self, o: object) -> bool:

--- a/conda_recipe_manager/parser/dependency.py
+++ b/conda_recipe_manager/parser/dependency.py
@@ -137,7 +137,7 @@ class DependencyVariable:
     def original_spec_str(self) -> str:
         """
         Property that allows the object to be used as a `MatchSpec` without type guards similarly to `name` above.
-        
+
         :returns: A string representing the original specification.
         """
         return self.name

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -301,7 +301,7 @@ class RecipeParserConvert(RecipeParserDeps):
                     spec_str = f"{spec_str}.*"
 
                 # Only commit changes to modified dependencies.
-                if dep_with_vars.data.original_spec_str == spec_str:
+                if cast(str, dep_with_vars.data.original_spec_str) == spec_str:
                     continue
 
                 # TODO add IGNORE conflict mode for selectors???

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -14,7 +14,7 @@ from conda_recipe_manager.licenses.spdx_utils import SpdxUtils
 from conda_recipe_manager.parser._message_table import MessageCategory, MessageTable
 from conda_recipe_manager.parser._types import ROOT_NODE_VALUE, CanonicalSortOrder, Regex
 from conda_recipe_manager.parser._utils import search_any_regex, set_key_conditionally, stack_path_to_str
-from conda_recipe_manager.parser.dependency import Dependency, DependencyConflictMode
+from conda_recipe_manager.parser.dependency import Dependency, DependencyConflictMode, dependency_data_from_str
 from conda_recipe_manager.parser.enums import SchemaVersion, SelectorConflictMode
 from conda_recipe_manager.parser.recipe_parser import RecipeParser
 from conda_recipe_manager.parser.recipe_parser_deps import RecipeParserDeps
@@ -244,7 +244,8 @@ class RecipeParserConvert(RecipeParserDeps):
         yet available.
         """
         try:
-            dep_map = self._v1_recipe.get_all_dependencies()
+            dep_map = self._v1_recipe.get_all_dependencies(sub_vars=True)
+            dep_map_with_vars = self._v1_recipe.get_all_dependencies(sub_vars=False)
         except (KeyError, ValueError):
             self._msg_tbl.add_message(
                 MessageCategory.ERROR,
@@ -252,8 +253,18 @@ class RecipeParserConvert(RecipeParserDeps):
             )
             return
 
-        for _, deps in dep_map.items():
-            for dep in deps:
+        for key, deps in dep_map.items():
+            deps_with_vars = dep_map_with_vars.get(key, deps)
+
+            if len(deps) != len(deps_with_vars):
+                self._msg_tbl.add_message(
+                    MessageCategory.ERROR,
+                    "Found different numbers of dependencies between dependencies with variable "
+                    "substitutuion versus without when attempting to upgrade ambiguous version numbers.",
+                )
+                return
+
+            for dep, dep_with_vars in zip(deps, deps_with_vars):
                 # Warn and quit-early if there is a potential for a ambiguous version variable.
                 if not isinstance(dep.data, MatchSpec):  # type: ignore[misc]
                     # TODO: Reduce spammy-ness by looking at the variables table
@@ -269,7 +280,7 @@ class RecipeParserConvert(RecipeParserDeps):
                 if dep.data.version is None or not isinstance(dep.data.original_spec_str, str):  # type: ignore[misc]
                     continue
 
-                spec_str = dep.data.original_spec_str
+                spec_str = dep_with_vars.data.original_spec_str
                 # Corrects fairly common typos when dealing with >= and <= operators in dependency version selection
                 # statements.
                 spec_str = Regex.AMBIGUOUS_DEP_VERSION_GE_TYPO.sub(r"\1>=\2", spec_str)
@@ -290,17 +301,17 @@ class RecipeParserConvert(RecipeParserDeps):
                     spec_str = f"{spec_str}.*"
 
                 # Only commit changes to modified dependencies.
-                if dep.data.original_spec_str == spec_str:
+                if dep_with_vars.data.original_spec_str == spec_str:
                     continue
 
                 # TODO add IGNORE conflict mode for selectors???
                 self._v1_recipe.add_dependency(
                     Dependency(
-                        required_by=dep.required_by,
-                        path=dep.path,
-                        type=dep.type,
-                        data=MatchSpec(spec_str),
-                        selector=dep.selector,
+                        required_by=dep_with_vars.required_by,
+                        path=dep_with_vars.path,
+                        type=dep_with_vars.type,
+                        data=dependency_data_from_str(spec_str),
+                        selector=dep_with_vars.selector,
                     ),
                     dep_mode=DependencyConflictMode.EXACT_POSITION,
                     sel_mode=SelectorConflictMode.OR,

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -280,7 +280,7 @@ class RecipeParserConvert(RecipeParserDeps):
                 if dep.data.version is None or not isinstance(dep.data.original_spec_str, str):  # type: ignore[misc]
                     continue
 
-                spec_str = dep_with_vars.data.original_spec_str
+                spec_str = cast(str, dep_with_vars.data.original_spec_str)
                 # Corrects fairly common typos when dealing with >= and <= operators in dependency version selection
                 # statements.
                 spec_str = Regex.AMBIGUOUS_DEP_VERSION_GE_TYPO.sub(r"\1>=\2", spec_str)

--- a/conda_recipe_manager/parser/recipe_reader_deps.py
+++ b/conda_recipe_manager/parser/recipe_reader_deps.py
@@ -166,12 +166,15 @@ class RecipeReaderDeps(RecipeReader):
                 )
             )
 
-    def get_all_dependencies(self, include_test_dependencies: bool = False) -> DependencyMap:
+    def get_all_dependencies(self, include_test_dependencies: bool = False, sub_vars: bool = True) -> DependencyMap:
         """
         Get a parsed representation of all the dependencies found in the recipe.
 
         :param include_test_dependencies: (Optional) If True, include test dependencies.
             Defaults to False, which will exclude test dependencies, for backwards compatibility.
+        :param sub_vars: (Optional) If set to True and the dependency contains a Jinja template
+            variable, the Jinja value will be "rendered". Any variables that can't be resolved
+            will be escaped with `${{ }}`. Defaults to True for backwards compatibility.
         :raises KeyError: If a package in the recipe does not have a name
         :raises ValueError: If a recipe contains a package with duplicate names
         :raises SentinelTypeEvaluationException: If a node value with a sentinel type is evaluated.
@@ -189,7 +192,7 @@ class RecipeReaderDeps(RecipeReader):
             # Requirements
             requirements = cast(
                 Optional[str | dict[str, list[Optional[str]]]],
-                self.get_value(RecipeReader.append_to_path(path, "/requirements"), default={}, sub_vars=True),
+                self.get_value(RecipeReader.append_to_path(path, "/requirements"), default={}, sub_vars=sub_vars),
             )
             # Skip over empty/malformed requirements sections
             if requirements is not None and not isinstance(requirements, str):
@@ -201,7 +204,7 @@ class RecipeReaderDeps(RecipeReader):
                 continue
             test_requirements = cast(
                 Optional[list[Optional[str]]],
-                self.get_value(RecipeReader.append_to_path(path, "/test/requires"), default=[], sub_vars=True),
+                self.get_value(RecipeReader.append_to_path(path, "/test/requires"), default=[], sub_vars=sub_vars),
             )
             # Skip over empty/malformed test requirements sections
             if test_requirements is not None and isinstance(test_requirements, list):

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -524,6 +524,15 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
                 "dependencies that use variables: {{ stdlib('c') }}",
             ],
         ),
+        (
+            "parser_regressions/issue-307-jinja2-ambig-vars.yaml",
+            [],
+            [
+                "Version on dependency changed to: python {{ python_min }}.*",
+                "Field at `/about/license_family` is no longer supported.",
+                "Field at `/about/doc_source_url` is no longer supported.",
+            ],
+        ),
     ],
 )
 def test_render_to_v1_recipe_format(file: str, errors: list[str], warnings: list[str]) -> None:

--- a/tests/test_aux_files/parser_regressions/issue-307-jinja2-ambig-vars.yaml
+++ b/tests/test_aux_files/parser_regressions/issue-307-jinja2-ambig-vars.yaml
@@ -1,0 +1,56 @@
+{% set name = "nbclient" %}
+{% set version = "0.11.0" %}
+{% set python_min = "3.10" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 04a134a5b087f2c5887f228aca155db50169b8cd9334dee6942c8e927e56081a
+
+build:
+  number: {{ build }}
+  script: {{ PYTHON }} -m pip install . -vv
+  noarch: python
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - pip
+    - hatchling
+  run:
+    - python >={{ python_min }}
+    - jupyter_client >=7.0.0
+    - jupyter_core >=5.4
+    - nbformat >=5.2.0
+    - traitlets >=5.13
+
+test:
+  requires:
+    - python {{ python_min }}
+    - pip
+  imports:
+    - nbclient
+  commands:
+    - pip check
+
+about:
+  home: https://jupyter.org
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: A client library for executing notebooks. Formally nbconvert's ExecutePreprocessor.
+  description: |
+    NBClient is a tool for parameterizing and executing Jupyter Notebooks.
+    NBClient lets you execute notebooks. Similar in nature to jupyter_client, as the jupyter_client
+    is to the jupyter protocol nbclient is to notebooks allowing for execution contexts to be run.
+  dev_url: https://github.com/jupyter/nbclient
+  doc_url: https://nbclient.readthedocs.io
+  doc_source_url: https://github.com/jupyter/nbclient/tree/master/docs
+
+extra:
+  recipe-maintainers:
+    - davidbrochart

--- a/tests/test_aux_files/parser_regressions/v1_format/v1_issue-307-jinja2-ambig-vars.yaml
+++ b/tests/test_aux_files/parser_regressions/v1_format/v1_issue-307-jinja2-ambig-vars.yaml
@@ -1,0 +1,55 @@
+schema_version: 1
+
+context:
+  name: nbclient
+  version: "0.11.0"
+  python_min: "3.10"
+  build: 0
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  sha256: 04a134a5b087f2c5887f228aca155db50169b8cd9334dee6942c8e927e56081a
+
+build:
+  number: ${{ build }}
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - hatchling
+  run:
+    - python >=${{ python_min }}
+    - jupyter_client >=7.0.0
+    - jupyter_core >=5.4
+    - nbformat >=5.2.0
+    - traitlets >=5.13
+
+tests:
+  - python:
+      imports:
+        - nbclient
+      pip_check: true
+      python_version: ${{ python_min }}
+
+about:
+  license: BSD-3-Clause
+  license_file: LICENSE
+  summary: A client library for executing notebooks. Formally nbconvert's ExecutePreprocessor.
+  description: |
+    NBClient is a tool for parameterizing and executing Jupyter Notebooks.
+    NBClient lets you execute notebooks. Similar in nature to jupyter_client, as the jupyter_client
+    is to the jupyter protocol nbclient is to notebooks allowing for execution contexts to be run.
+  homepage: https://jupyter.org
+  repository: https://github.com/jupyter/nbclient
+  documentation: https://nbclient.readthedocs.io
+
+extra:
+  recipe-maintainers:
+    - davidbrochart


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR fixes a bug where jinja2 variables are replaced while ambiguous variables are handled when converting to v1.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-recipe-manager/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-recipe-manager/blob/main/CONTRIBUTING.md -->

closes #307 