### PR TITLE
Pins `click` in `pyproject.toml` and upgrades `click` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: version releases in the 0.x.y range may introduce breaking changes.
 ## [Unreleased]
 ### Added
 ### Changed
+- `click` dependency has been pinned to 8.4.1, which is available on `defaults` and `conda-forge`
+  channels for Python 3.11-3.14.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/environment.yaml
+++ b/environment.yaml
@@ -17,7 +17,7 @@ dependencies:
   # Match version with .pre-commit-config.yaml to ensure consistent rules with `make lint`.
   - pylint ==4.0.4
   - pip
-  - click 8.2.1
+  - click 8.4.1
   - conda
   - evalidate >=2.0.3,<3.0.0
   - jinja2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-  "click",
+  "click==8.4.1",
   "jinja2",
   "pyyaml",
   "jsonschema",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,8 @@ requirements:
   run:
     - python >=3.11
     # `click` has historically given us some grief with breaking changes between minor versions, so we hard-pin it.
-    # 8.2.1 is available on `defaults` and `conda-forge` for Python 3.11+.
-    - click ==8.2.1
+    # 8.4.1 is available on `defaults` and `conda-forge` for Python 3.11+.
+    - click ==8.4.1
     - conda
     - jinja2
     - pyyaml


### PR DESCRIPTION
- Pins `click` in the `pyproject.toml` file, as discovered in https://github.com/conda-forge/conda-recipe-manager-feedstock/pull/44
  - We continue to be bad at keeping the `pyproject.toml` aligned with the conda recipe file for this project.
- While we are at it, also bumps the `click` pinning. In my brief testing, this looks safe. I'll be curious to see the integration tests pass (which calls a number of CRM `click`-based scripts)