### PR TITLE
Adds package builder warning

### DIFF
--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -25,6 +25,8 @@ StrStackImmutable = tuple[str, ...]
 
 #### Private Constants (Not to be used external to the `parser` module) ####
 
+# String that represents the top-level path to a document.
+ROOT_PATH: Final[str] = "/"
 # String that represents a root node in our path.
 ROOT_NODE_VALUE: Final[str] = "/"
 # Marker used to temporarily work around some Jinja-template parsing issues

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -12,7 +12,7 @@ from conda.models.match_spec import MatchSpec
 
 from conda_recipe_manager.licenses.spdx_utils import SpdxUtils
 from conda_recipe_manager.parser._message_table import MessageCategory, MessageTable
-from conda_recipe_manager.parser._types import ROOT_NODE_VALUE, CanonicalSortOrder, Regex
+from conda_recipe_manager.parser._types import ROOT_NODE_VALUE, ROOT_PATH, CanonicalSortOrder, Regex
 from conda_recipe_manager.parser._utils import search_any_regex, set_key_conditionally, stack_path_to_str
 from conda_recipe_manager.parser.dependency import Dependency, DependencyConflictMode, dependency_data_from_str
 from conda_recipe_manager.parser.enums import SchemaVersion, SelectorConflictMode
@@ -676,10 +676,32 @@ class RecipeParserConvert(RecipeParserDeps):
 
         :param base_package_paths: Set of base paths to process that could contain this section.
         """
+        detect_and_warn_top_level_requirements_once = False
         for base_path in base_package_paths:
             requirements_path = RecipeParser.append_to_path(base_path, "/requirements")
             if not self._v1_recipe.contains_value(requirements_path):
                 continue
+
+            # While we are modifying all the changes that need to be made in the `/requirements` section, detect and
+            # produce 1 warning indicating if there is a top-level `/requirements` section and at least one other in a
+            # multi-output recipe. This dual-context situation in V0 is rarely used and has an _incredibly_ nuanced
+            # interpretation in `conda-build`. Given that, we do not attempt to remedy the situation and alert the
+            # the package builder that they will have to manually fix this.
+            if base_path == ROOT_PATH:
+                detect_and_warn_top_level_requirements_once = True
+            # If this was set AND we have found another `/requirements` section in a following iteration, we have _the_
+            # problem.
+            elif detect_and_warn_top_level_requirements_once:
+                self._msg_tbl.add_message(
+                    MessageCategory.WARNING,
+                    (
+                        "This recipe contains a top-level `/requirements` section and at least one"
+                        " `/outputs/*/requirements` section. Manual intervention will be required to match expected"
+                        " V0 build behavior in V1."
+                    ),
+                )
+                # Reset to fail on the next iteration, warning only one time.
+                detect_and_warn_top_level_requirements_once = False
 
             # Renames `run_constrained` to the new equivalent name
             self._patch_move_base_path(requirements_path, "/run_constrained", "/run_constraints")
@@ -1089,7 +1111,7 @@ class RecipeParserConvert(RecipeParserDeps):
         # Sort the top-level keys to a "canonical" ordering. This should make previous patch operations look more
         # "sensible" to a human reader.
         self._v1_recipe._sort_subtree_keys(  # pylint: disable=protected-access
-            "/", CanonicalSortOrder.TOP_LEVEL_KEY_SORT_ORDER
+            ROOT_PATH, CanonicalSortOrder.TOP_LEVEL_KEY_SORT_ORDER
         )
 
         # Override the schema value as the recipe conversion is now complete.

--- a/conda_recipe_manager/parser/recipe_reader.py
+++ b/conda_recipe_manager/parser/recipe_reader.py
@@ -25,6 +25,7 @@ from conda_recipe_manager.parser._traverse import traverse, traverse_all
 from conda_recipe_manager.parser._types import (
     RECIPE_MANAGER_SUB_MARKER,
     ROOT_NODE_VALUE,
+    ROOT_PATH,
     ForceIndentDumper,
     Regex,
     SafeLoader,
@@ -1558,8 +1559,10 @@ class RecipeReader(IsModifiable):
               https://github.com/AnacondaRecipes/curl-feedstock/blob/master/recipe/meta.yaml
 
         :raises SentinelTypeEvaluationException: If a node value with a sentinel type is evaluated.
+        :returns: List of path prefixes, indicating "packages". ALWAYS begins with the top-level path, followed by
+            any `/outputs/*` paths, if applicable.
         """
-        paths: list[str] = ["/"]
+        paths: list[str] = [ROOT_PATH]
 
         outputs: Final[list[str]] = cast(list[str], self.get_value("/outputs", []))
         for i in range(len(outputs)):

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -123,6 +123,11 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
                 "dependencies that use variables: {{ compiler('c') }}",
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
                 "dependencies that use variables: {{ compiler('cxx') }}",
+                (
+                    "This recipe contains a top-level `/requirements` section and at least one"
+                    " `/outputs/*/requirements` section. Manual intervention will be required to match expected V0"
+                    " build behavior in V1."
+                ),
                 "Field at `/about/license_family` is no longer supported.",
             ],
         ),
@@ -149,6 +154,11 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
             "cctools-ld64.yaml",
             [],
             [
+                (
+                    "This recipe contains a top-level `/requirements` section and at least one"
+                    " `/outputs/*/requirements` section. Manual intervention will be required to match expected V0"
+                    " build behavior in V1."
+                ),
                 "Changed /outputs/0/about/license from `Apple Public Source License 2.0` to " "`APSL-2.0`",
                 "Field at `/outputs/0/about/license_family` is no longer supported.",
                 "Changed /outputs/1/about/license from `Apple Public Source License 2.0` to " "`APSL-2.0`",
@@ -559,7 +569,16 @@ def test_render_to_v1_recipe_format(file: str, errors: list[str], warnings: list
         (
             "parser_regressions/run_exports_as_list.yaml",
             [],
-            [],
+            [
+                # NOTE: The original V0 recipe does not contain both `/requirements` section contexts. HOWEVER the
+                #       resulting V1 recipe DOES contain both, because `run_exports` moved to the `/requirements`
+                #       section in V1. So a package builder should still be made aware.
+                (
+                    "This recipe contains a top-level `/requirements` section and at least one"
+                    " `/outputs/*/requirements` section. Manual intervention will be required to match expected V0"
+                    " build behavior in V1."
+                ),
+            ],
         ),
     ],
 )


### PR DESCRIPTION
- Warns package builders when a V1 recipe contains "dual-context" `/requirements` sections. This is an incredibly nuanced feature of V0 that is no longer supported in V1.
- Adds a new `ROOT_PATH` constant that has an identical value as `ROOT_NODE_VALUE` but is used in a completely different meaning. This eliminates a few magic string instances of "/", in favor of said constant.
- Updates tests