### PR TITLE
fix: handle more ambiguous spec edge cases for simple jinja2 statements and in test deps

### DIFF
--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -226,7 +226,6 @@ class Regex:
 
     ## Jinja regular expressions ##
     JINJA_V0_SUB: Final[re.Pattern[str]] = re.compile(r"{{\s*" + _JINJA_VAR_FUNCTION_PATTERN + r"\s*}}")
-
     # Detects multi-line JINJA statements.
     # re.DOTALL is used to allow for multiline matches and '?' is used to make the quantifier '.+' non-greedy,
     # allowing for the shortest possible match, in order to avoid matching all the way to the last JINJA statement

--- a/conda_recipe_manager/parser/_types.py
+++ b/conda_recipe_manager/parser/_types.py
@@ -210,6 +210,9 @@ class Regex:
     AMBIGUOUS_DEP_MULTI_OPERATOR: Final[re.Pattern[str]] = re.compile(
         r"([\w|\-]+\s*)(~|<|>|<=|>=|==|!=|~=)(\s*[\d|\.]+)(\.\*)"
     )
+    AMBIGUOUS_DEP_JINJA_VAR: Final[re.Pattern[str]] = re.compile(
+        r"^\s*((([a-z0-9])|([a-z0-9_](?!_)))[._-]?([a-z0-9]+(\.|-|_|))*)\s*\$?\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}$"
+    )
 
     ## Selector Replacements ##
     # Replaces Python version expressions with the newer V1 `match()` function
@@ -223,6 +226,7 @@ class Regex:
 
     ## Jinja regular expressions ##
     JINJA_V0_SUB: Final[re.Pattern[str]] = re.compile(r"{{\s*" + _JINJA_VAR_FUNCTION_PATTERN + r"\s*}}")
+
     # Detects multi-line JINJA statements.
     # re.DOTALL is used to allow for multiline matches and '?' is used to make the quantifier '.+' non-greedy,
     # allowing for the shortest possible match, in order to avoid matching all the way to the last JINJA statement

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -266,7 +266,9 @@ class RecipeParserConvert(RecipeParserDeps):
 
             for dep, dep_with_vars in zip(deps, deps_with_vars):
                 # Warn and quit-early if there is a potential for a ambiguous version variable.
-                if not isinstance(dep.data, MatchSpec):  # type: ignore[misc]
+                if (not isinstance(dep.data, MatchSpec)) and (
+                    not Regex.AMBIGUOUS_DEP_JINJA_VAR.match(dep_with_vars.data.original_spec_str)
+                ):  # type: ignore[misc]
                     # TODO: Reduce spammy-ness by looking at the variables table
                     self._msg_tbl.add_message(
                         MessageCategory.WARNING,
@@ -277,7 +279,9 @@ class RecipeParserConvert(RecipeParserDeps):
                     )
                     continue
 
-                if dep.data.version is None or not isinstance(dep.data.original_spec_str, str):  # type: ignore[misc]
+                if isinstance(dep.data, MatchSpec) and (
+                    dep.data.version is None or not isinstance(dep.data.original_spec_str, str)
+                ):  # type: ignore[misc]
                     continue
 
                 spec_str = cast(str, dep_with_vars.data.original_spec_str)
@@ -295,9 +299,10 @@ class RecipeParserConvert(RecipeParserDeps):
                 # `VersionSpec` does not make a distinction between a version that contains a `==` operator and a
                 # version with no operator (which is ambiguous per the V1 specification).
                 if (
-                    cast(bool, dep.data.version.is_exact())  # type: ignore[misc]
+                    isinstance(dep.data, MatchSpec)
+                    and cast(bool, dep.data.version.is_exact())  # type: ignore[misc]
                     and "=" not in dep.data.original_spec_str
-                ):
+                ) or Regex.AMBIGUOUS_DEP_JINJA_VAR.match(dep_with_vars.data.original_spec_str):
                     spec_str = f"{spec_str}.*"
 
                 # Only commit changes to modified dependencies.

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -244,8 +244,8 @@ class RecipeParserConvert(RecipeParserDeps):
         yet available.
         """
         try:
-            dep_map = self._v1_recipe.get_all_dependencies(sub_vars=True)
-            dep_map_with_vars = self._v1_recipe.get_all_dependencies(sub_vars=False)
+            dep_map = self._v1_recipe.get_all_dependencies(sub_vars=True, include_test_dependencies=True)
+            dep_map_with_vars = self._v1_recipe.get_all_dependencies(sub_vars=False, include_test_dependencies=True)
         except (KeyError, ValueError):
             self._msg_tbl.add_message(
                 MessageCategory.ERROR,

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -266,9 +266,9 @@ class RecipeParserConvert(RecipeParserDeps):
 
             for dep, dep_with_vars in zip(deps, deps_with_vars):
                 # Warn and quit-early if there is a potential for a ambiguous version variable.
-                if (not isinstance(dep.data, MatchSpec)) and (
-                    not Regex.AMBIGUOUS_DEP_JINJA_VAR.match(dep_with_vars.data.original_spec_str)
-                ):  # type: ignore[misc]
+                if (not isinstance(dep.data, MatchSpec)) and (  # type: ignore[misc]
+                    not Regex.AMBIGUOUS_DEP_JINJA_VAR.match(dep_with_vars.data.original_spec_str)  # type: ignore[misc]
+                ):
                     # TODO: Reduce spammy-ness by looking at the variables table
                     self._msg_tbl.add_message(
                         MessageCategory.WARNING,
@@ -279,9 +279,9 @@ class RecipeParserConvert(RecipeParserDeps):
                     )
                     continue
 
-                if isinstance(dep.data, MatchSpec) and (
-                    dep.data.version is None or not isinstance(dep.data.original_spec_str, str)
-                ):  # type: ignore[misc]
+                if isinstance(dep.data, MatchSpec) and (  # type: ignore[misc]
+                    dep.data.version is None or not isinstance(dep.data.original_spec_str, str)  # type: ignore[misc]
+                ):
                     continue
 
                 spec_str = cast(str, dep_with_vars.data.original_spec_str)
@@ -299,10 +299,10 @@ class RecipeParserConvert(RecipeParserDeps):
                 # `VersionSpec` does not make a distinction between a version that contains a `==` operator and a
                 # version with no operator (which is ambiguous per the V1 specification).
                 if (
-                    isinstance(dep.data, MatchSpec)
+                    isinstance(dep.data, MatchSpec)  # type: ignore[misc]
                     and cast(bool, dep.data.version.is_exact())  # type: ignore[misc]
-                    and "=" not in dep.data.original_spec_str
-                ) or Regex.AMBIGUOUS_DEP_JINJA_VAR.match(dep_with_vars.data.original_spec_str):
+                    and "=" not in dep.data.original_spec_str  # type: ignore[misc]
+                ) or Regex.AMBIGUOUS_DEP_JINJA_VAR.match(dep_with_vars.data.original_spec_str):  # type: ignore[misc]
                     spec_str = f"{spec_str}.*"
 
                 # Only commit changes to modified dependencies.

--- a/conda_recipe_manager/parser/recipe_parser_convert.py
+++ b/conda_recipe_manager/parser/recipe_parser_convert.py
@@ -302,7 +302,9 @@ class RecipeParserConvert(RecipeParserDeps):
                     isinstance(dep.data, MatchSpec)  # type: ignore[misc]
                     and cast(bool, dep.data.version.is_exact())  # type: ignore[misc]
                     and "=" not in dep.data.original_spec_str  # type: ignore[misc]
-                ) or Regex.AMBIGUOUS_DEP_JINJA_VAR.match(dep_with_vars.data.original_spec_str):  # type: ignore[misc]
+                ) or (
+                    Regex.AMBIGUOUS_DEP_JINJA_VAR.match(dep_with_vars.data.original_spec_str)  # type: ignore[misc]
+                ):
                     spec_str = f"{spec_str}.*"
 
                 # Only commit changes to modified dependencies.

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -543,6 +543,17 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
                 "Field at `/about/doc_source_url` is no longer supported.",
             ],
         ),
+        (
+            "parser_regressions/issue-307-jinja2-ambig-vars-notset.yaml",
+            [],
+            [
+                "Version on dependency changed to: python {{ python_min }}.*",
+                "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
+                "dependencies that use variables: python >={{ python_min }}",
+                "Field at `/about/license_family` is no longer supported.",
+                "Field at `/about/doc_source_url` is no longer supported.",
+            ],
+        ),
     ],
 )
 def test_render_to_v1_recipe_format(file: str, errors: list[str], warnings: list[str]) -> None:

--- a/tests/parser/test_recipe_parser_convert.py
+++ b/tests/parser/test_recipe_parser_convert.py
@@ -110,6 +110,8 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
                 'dependencies that use variables: {{ pin_subpackage("libgoogle-cloud-all", '
                 "exact=True) }}",
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
+                "dependencies that use variables: {{ compiler('cxx') }}",
+                "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
                 "dependencies that use variables: {{ compiler('c') }}",
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
                 "dependencies that use variables: {{ compiler('cxx') }}",
@@ -539,6 +541,7 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
             [],
             [
                 "Version on dependency changed to: python {{ python_min }}.*",
+                "Version on dependency changed to: python {{ python_min }}.*",
                 "Field at `/about/license_family` is no longer supported.",
                 "Field at `/about/doc_source_url` is no longer supported.",
             ],
@@ -550,8 +553,7 @@ def test_pre_process_recipe_text(input_file: str, expected_file: str) -> None:
                 "Version on dependency changed to: python {{ python_min }}.*",
                 "Recipe upgrades cannot currently upgrade ambiguous version constraints on "
                 "dependencies that use variables: python >={{ python_min }}",
-                "Field at `/about/license_family` is no longer supported.",
-                "Field at `/about/doc_source_url` is no longer supported.",
+                "Version on dependency changed to: python {{ python_min }}.*",
             ],
         ),
     ],

--- a/tests/test_aux_files/parser_regressions/issue-307-jinja2-ambig-vars-notset.yaml
+++ b/tests/test_aux_files/parser_regressions/issue-307-jinja2-ambig-vars-notset.yaml
@@ -1,55 +1,65 @@
-{% set name = "nbclient" %}
-{% set version = "0.11.0" %}
-{% set build = 0 %}
+{% set name = "conda-index" %}
+{% set version = "0.12.1" %}
 
 package:
-  name: {{ name }}
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 04a134a5b087f2c5887f228aca155db50169b8cd9334dee6942c8e927e56081a
+  url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 08586a4d67d0faea679721b434a1e2df5a26ed58b6b0d7e62d19e5ada803e380
 
 build:
-  number: {{ build }}
-  script: {{ PYTHON }} -m pip install . -vv
+  script_env:
+    - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
+  script: {{ PYTHON }} -m pip install --no-build-isolation . -vv
+  number: 0
   noarch: python
 
 requirements:
   host:
+    - hatchling >=1.12.2
+    - hatch-vcs >=0.2.0
     - python {{ python_min }}
     - pip
-    - hatchling
   run:
     - python >={{ python_min }}
-    - jupyter_client >=7.0.0
-    - jupyter_core >=5.4
-    - nbformat >=5.2.0
-    - traitlets >=5.13
+    - conda >=25
+    - conda-package-streaming >=0.12.0
+    - filelock
+    - jinja2
+    - msgpack-python >=1.0.2
+    - ruamel.yaml
+    - zstandard
 
 test:
   requires:
+    - conda-build >=25
+    - conda-package-handling >=2.2.0
+    - coverage
+    - fsspec
+    - pytest >=7
+    - pytest-cov
+    - pytest-mock
     - python {{ python_min }}
-    - pip
-  imports:
-    - nbclient
   commands:
-    - pip check
+    - pytest -k test_index_on_single_subdir_1
+  imports:
+    - conda_index.index
+  source_files:
+    - tests
 
 about:
-  home: https://jupyter.org
+  home: https://github.com/conda/conda-index
+  summary: Create `repodata.json` for collections of conda packages.
   license: BSD-3-Clause
-  license_family: BSD
   license_file: LICENSE
-  summary: A client library for executing notebooks. Formally nbconvert's ExecutePreprocessor.
-  description: |
-    NBClient is a tool for parameterizing and executing Jupyter Notebooks.
-    NBClient lets you execute notebooks. Similar in nature to jupyter_client, as the jupyter_client
-    is to the jupyter protocol nbclient is to notebooks allowing for execution contexts to be run.
-  dev_url: https://github.com/jupyter/nbclient
-  doc_url: https://nbclient.readthedocs.io
-  doc_source_url: https://github.com/jupyter/nbclient/tree/master/docs
+  doc_url: https://conda.github.io/conda-index
+  dev_url: https://github.com/conda/conda-index
 
 extra:
   recipe-maintainers:
-    - davidbrochart
+    - kenodegard
+    - AndresGuzman-Ballen
+    - dholth
+    - jharlow-intel

--- a/tests/test_aux_files/parser_regressions/issue-307-jinja2-ambig-vars-notset.yaml
+++ b/tests/test_aux_files/parser_regressions/issue-307-jinja2-ambig-vars-notset.yaml
@@ -1,0 +1,55 @@
+{% set name = "nbclient" %}
+{% set version = "0.11.0" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 04a134a5b087f2c5887f228aca155db50169b8cd9334dee6942c8e927e56081a
+
+build:
+  number: {{ build }}
+  script: {{ PYTHON }} -m pip install . -vv
+  noarch: python
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - pip
+    - hatchling
+  run:
+    - python >={{ python_min }}
+    - jupyter_client >=7.0.0
+    - jupyter_core >=5.4
+    - nbformat >=5.2.0
+    - traitlets >=5.13
+
+test:
+  requires:
+    - python {{ python_min }}
+    - pip
+  imports:
+    - nbclient
+  commands:
+    - pip check
+
+about:
+  home: https://jupyter.org
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: A client library for executing notebooks. Formally nbconvert's ExecutePreprocessor.
+  description: |
+    NBClient is a tool for parameterizing and executing Jupyter Notebooks.
+    NBClient lets you execute notebooks. Similar in nature to jupyter_client, as the jupyter_client
+    is to the jupyter protocol nbclient is to notebooks allowing for execution contexts to be run.
+  dev_url: https://github.com/jupyter/nbclient
+  doc_url: https://nbclient.readthedocs.io
+  doc_source_url: https://github.com/jupyter/nbclient/tree/master/docs
+
+extra:
+  recipe-maintainers:
+    - davidbrochart

--- a/tests/test_aux_files/parser_regressions/v1_format/v1_issue-307-jinja2-ambig-vars-notset.yaml
+++ b/tests/test_aux_files/parser_regressions/v1_format/v1_issue-307-jinja2-ambig-vars-notset.yaml
@@ -1,0 +1,54 @@
+schema_version: 1
+
+context:
+  name: nbclient
+  version: "0.11.0"
+  build: 0
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  sha256: 04a134a5b087f2c5887f228aca155db50169b8cd9334dee6942c8e927e56081a
+
+build:
+  number: ${{ build }}
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - hatchling
+  run:
+    - python >=${{ python_min }}
+    - jupyter_client >=7.0.0
+    - jupyter_core >=5.4
+    - nbformat >=5.2.0
+    - traitlets >=5.13
+
+tests:
+  - python:
+      imports:
+        - nbclient
+      pip_check: true
+      python_version: ${{ python_min }}
+
+about:
+  license: BSD-3-Clause
+  license_file: LICENSE
+  summary: A client library for executing notebooks. Formally nbconvert's ExecutePreprocessor.
+  description: |
+    NBClient is a tool for parameterizing and executing Jupyter Notebooks.
+    NBClient lets you execute notebooks. Similar in nature to jupyter_client, as the jupyter_client
+    is to the jupyter protocol nbclient is to notebooks allowing for execution contexts to be run.
+  homepage: https://jupyter.org
+  repository: https://github.com/jupyter/nbclient
+  documentation: https://nbclient.readthedocs.io
+
+extra:
+  recipe-maintainers:
+    - davidbrochart

--- a/tests/test_aux_files/parser_regressions/v1_format/v1_issue-307-jinja2-ambig-vars-notset.yaml
+++ b/tests/test_aux_files/parser_regressions/v1_format/v1_issue-307-jinja2-ambig-vars-notset.yaml
@@ -1,54 +1,74 @@
 schema_version: 1
 
 context:
-  name: nbclient
-  version: "0.11.0"
-  build: 0
+  name: conda-index
+  version: "0.12.1"
 
 package:
-  name: ${{ name }}
+  name: ${{ name|lower }}
   version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
-  sha256: 04a134a5b087f2c5887f228aca155db50169b8cd9334dee6942c8e927e56081a
+  url: https://github.com/conda/${{ name }}/archive/refs/tags/${{ version }}.tar.gz
+  sha256: 08586a4d67d0faea679721b434a1e2df5a26ed58b6b0d7e62d19e5ada803e380
 
 build:
-  number: ${{ build }}
+  number: 0
   noarch: python
-  script: ${{ PYTHON }} -m pip install . -vv
+  script:
+    env:
+      SETUPTOOLS_SCM_PRETEND_VERSION: ${{ version }}
+    content: ${{ PYTHON }} -m pip install --no-build-isolation . -vv
 
 requirements:
   host:
+    - hatchling >=1.12.2
+    - hatch-vcs >=0.2.0
     - python ${{ python_min }}.*
     - pip
-    - hatchling
   run:
     - python >=${{ python_min }}
-    - jupyter_client >=7.0.0
-    - jupyter_core >=5.4
-    - nbformat >=5.2.0
-    - traitlets >=5.13
+    - conda >=25
+    - conda-package-streaming >=0.12.0
+    - filelock
+    - jinja2
+    - msgpack-python >=1.0.2
+    - ruamel.yaml
+    - zstandard
 
 tests:
   - python:
       imports:
-        - nbclient
-      pip_check: true
-      python_version: ${{ python_min }}
+        - conda_index.index
+      pip_check: false
+      python_version: ${{ python_min }}.*
+  - files:
+      source:
+        - tests
+    requirements:
+      run:
+        - conda-build >=25
+        - conda-package-handling >=2.2.0
+        - coverage
+        - fsspec
+        - pytest >=7
+        - pytest-cov
+        - pytest-mock
+        - python ${{ python_min }}.*
+    script:
+      - pytest -k test_index_on_single_subdir_1
 
 about:
+  summary: Create `repodata.json` for collections of conda packages.
   license: BSD-3-Clause
   license_file: LICENSE
-  summary: A client library for executing notebooks. Formally nbconvert's ExecutePreprocessor.
-  description: |
-    NBClient is a tool for parameterizing and executing Jupyter Notebooks.
-    NBClient lets you execute notebooks. Similar in nature to jupyter_client, as the jupyter_client
-    is to the jupyter protocol nbclient is to notebooks allowing for execution contexts to be run.
-  homepage: https://jupyter.org
-  repository: https://github.com/jupyter/nbclient
-  documentation: https://nbclient.readthedocs.io
+  homepage: https://github.com/conda/conda-index
+  repository: https://github.com/conda/conda-index
+  documentation: https://conda.github.io/conda-index
 
 extra:
   recipe-maintainers:
-    - davidbrochart
+    - kenodegard
+    - AndresGuzman-Ballen
+    - dholth
+    - jharlow-intel

--- a/tests/test_aux_files/parser_regressions/v1_format/v1_issue-307-jinja2-ambig-vars.yaml
+++ b/tests/test_aux_files/parser_regressions/v1_format/v1_issue-307-jinja2-ambig-vars.yaml
@@ -36,7 +36,7 @@ tests:
       imports:
         - nbclient
       pip_check: true
-      python_version: ${{ python_min }}
+      python_version: ${{ python_min }}.*
 
 about:
   license: BSD-3-Clause


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR fixes edge cases where the conversion function does not add `.*` to specs like `python {{ python_min }}` when `python_min` does not have a corresponding set statement.

It also fixes cases where ambiguous test deps were not converted.

closes #307 