### PR TITLE
Widens click dependency range, per community feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Note: version releases in the 0.x.y range may introduce breaking changes.
 ## [Unreleased]
 ### Added
 ### Changed
+- Widened `click` dependency has been pinning to allow for more known safe versions, per community feedback.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/environment.yaml
+++ b/environment.yaml
@@ -17,7 +17,7 @@ dependencies:
   # Match version with .pre-commit-config.yaml to ensure consistent rules with `make lint`.
   - pylint ==4.0.4
   - pip
-  - click ==8.4.1
+  - click >=8.2.1,<=8.4.1
   - conda
   - evalidate >=2.0.3,<3.0.0
   - jinja2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-  "click==8.4.1",
+  "click>=8.2.1,<=8.4.1",
   "jinja2",
   "pyyaml",
   "jsonschema",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,9 +24,10 @@ requirements:
     - wheel
   run:
     - python >=3.11
-    # `click` has historically given us some grief with breaking changes between minor versions, so we hard-pin it.
-    # 8.4.1 is available on `defaults` and `conda-forge` for Python 3.11+.
-    - click ==8.4.1
+    # `click` has historically given us some grief with breaking changes between minor versions, so we restrict it.
+    # As of writing, 8.4.1 is the latest known working available version on Anaconda's `main` channel and `conda-forge`
+    # for Python 3.11+.
+    - click >=8.2.1,<=8.4.1
     - conda
     - jinja2
     - pyyaml


### PR DESCRIPTION
This should give us a "best of both worlds" scenario: allow more options while also only allowing versions we have confidence won't break users.